### PR TITLE
Add k6 gRPC test suite with GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -59,6 +59,8 @@ jobs:
           sudo apt-get install -y k6
 
       - name: Run match_timeline_sports
+        id: test_match_timeline_sports
+        continue-on-error: true
         if: ${{ inputs.run_match_timeline_sports != false }}
         working-directory: k6
         run: k6 run match_timeline_sports.js
@@ -66,6 +68,8 @@ jobs:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_tournaments
+        id: test_match_timeline_tournaments
+        continue-on-error: true
         if: ${{ inputs.run_match_timeline_tournaments != false }}
         working-directory: k6
         run: k6 run match_timeline_tournaments.js
@@ -73,6 +77,8 @@ jobs:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_filters
+        id: test_match_timeline_filters
+        continue-on-error: true
         if: ${{ inputs.run_match_timeline_filters != false }}
         working-directory: k6
         run: k6 run match_timeline_filters.js
@@ -80,6 +86,8 @@ jobs:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run team_profile
+        id: test_team_profile
+        continue-on-error: true
         if: ${{ inputs.run_team_profile != false }}
         working-directory: k6
         run: k6 run team_profile.js
@@ -87,6 +95,8 @@ jobs:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_feed
+        id: test_match_timeline_feed
+        continue-on-error: true
         if: ${{ inputs.run_match_timeline_feed != false }}
         working-directory: k6
         run: k6 run match_timeline_feed.js
@@ -94,6 +104,8 @@ jobs:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_sports_feed
+        id: test_match_timeline_sports_feed
+        continue-on-error: true
         if: ${{ inputs.run_match_timeline_sports_feed != false }}
         working-directory: k6
         run: k6 run match_timeline_sports_feed.js
@@ -101,6 +113,8 @@ jobs:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_tournaments_feed
+        id: test_match_timeline_tournaments_feed
+        continue-on-error: true
         if: ${{ inputs.run_match_timeline_tournaments_feed != false }}
         working-directory: k6
         run: k6 run match_timeline_tournaments_feed.js
@@ -108,6 +122,8 @@ jobs:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run live_data_feed
+        id: test_live_data_feed
+        continue-on-error: true
         if: ${{ inputs.run_live_data_feed != false }}
         working-directory: k6
         run: k6 run live_data_feed.js
@@ -115,8 +131,29 @@ jobs:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_events_feed
+        id: test_match_events_feed
+        continue-on-error: true
         if: ${{ inputs.run_match_events_feed != false }}
         working-directory: k6
         run: k6 run match_events_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
+
+      - name: Check test results
+        if: always()
+        run: |
+          failed=false
+          # check each step outcome
+          if [ "${{ steps.test_match_timeline_sports.outcome }}" = "failure" ]; then failed=true; fi
+          if [ "${{ steps.test_match_timeline_tournaments.outcome }}" = "failure" ]; then failed=true; fi
+          if [ "${{ steps.test_match_timeline_filters.outcome }}" = "failure" ]; then failed=true; fi
+          if [ "${{ steps.test_team_profile.outcome }}" = "failure" ]; then failed=true; fi
+          if [ "${{ steps.test_match_timeline_feed.outcome }}" = "failure" ]; then failed=true; fi
+          if [ "${{ steps.test_match_timeline_sports_feed.outcome }}" = "failure" ]; then failed=true; fi
+          if [ "${{ steps.test_match_timeline_tournaments_feed.outcome }}" = "failure" ]; then failed=true; fi
+          if [ "${{ steps.test_live_data_feed.outcome }}" = "failure" ]; then failed=true; fi
+          if [ "${{ steps.test_match_events_feed.outcome }}" = "failure" ]; then failed=true; fi
+          if [ "$failed" = "true" ]; then
+            echo "One or more k6 tests failed"
+            exit 1
+          fi

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -4,6 +4,43 @@ on:
   schedule:
     - cron: '0 6 * * *' # Daily at 06:00 UTC
   workflow_dispatch:
+    inputs:
+      run_match_timeline_sports:
+        description: 'Run match_timeline_sports test'
+        type: boolean
+        default: true
+      run_match_timeline_tournaments:
+        description: 'Run match_timeline_tournaments test'
+        type: boolean
+        default: true
+      run_match_timeline_filters:
+        description: 'Run match_timeline_filters test'
+        type: boolean
+        default: true
+      run_team_profile:
+        description: 'Run team_profile test'
+        type: boolean
+        default: true
+      run_match_timeline_feed:
+        description: 'Run match_timeline_feed test'
+        type: boolean
+        default: true
+      run_match_timeline_sports_feed:
+        description: 'Run match_timeline_sports_feed test'
+        type: boolean
+        default: true
+      run_match_timeline_tournaments_feed:
+        description: 'Run match_timeline_tournaments_feed test'
+        type: boolean
+        default: true
+      run_live_data_feed:
+        description: 'Run live_data_feed test'
+        type: boolean
+        default: true
+      run_match_events_feed:
+        description: 'Run match_events_feed test'
+        type: boolean
+        default: true
 
 jobs:
   k6-tests:
@@ -22,46 +59,55 @@ jobs:
           sudo apt-get install -y k6
 
       - name: Run match_timeline_sports
+        if: ${{ inputs.run_match_timeline_sports != false }}
         run: k6 run k6/match_timeline_sports.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_tournaments
+        if: ${{ inputs.run_match_timeline_tournaments != false }}
         run: k6 run k6/match_timeline_tournaments.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_filters
+        if: ${{ inputs.run_match_timeline_filters != false }}
         run: k6 run k6/match_timeline_filters.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run team_profile
+        if: ${{ inputs.run_team_profile != false }}
         run: k6 run k6/team_profile.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_feed
+        if: ${{ inputs.run_match_timeline_feed != false }}
         run: k6 run k6/match_timeline_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_sports_feed
+        if: ${{ inputs.run_match_timeline_sports_feed != false }}
         run: k6 run k6/match_timeline_sports_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_tournaments_feed
+        if: ${{ inputs.run_match_timeline_tournaments_feed != false }}
         run: k6 run k6/match_timeline_tournaments_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run live_data_feed
+        if: ${{ inputs.run_live_data_feed != false }}
         run: k6 run k6/live_data_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_events_feed
+        if: ${{ inputs.run_match_events_feed != false }}
         run: k6 run k6/match_events_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   k6-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run match_timeline_sports
         id: test_match_timeline_sports
         continue-on-error: true
-        if: ${{ inputs.run_match_timeline_sports != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_match_timeline_sports }}
         working-directory: k6
         run: k6 run match_timeline_sports.js
         env:
@@ -70,7 +70,7 @@ jobs:
       - name: Run match_timeline_tournaments
         id: test_match_timeline_tournaments
         continue-on-error: true
-        if: ${{ inputs.run_match_timeline_tournaments != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_match_timeline_tournaments }}
         working-directory: k6
         run: k6 run match_timeline_tournaments.js
         env:
@@ -79,7 +79,7 @@ jobs:
       - name: Run match_timeline_filters
         id: test_match_timeline_filters
         continue-on-error: true
-        if: ${{ inputs.run_match_timeline_filters != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_match_timeline_filters }}
         working-directory: k6
         run: k6 run match_timeline_filters.js
         env:
@@ -88,7 +88,7 @@ jobs:
       - name: Run team_profile
         id: test_team_profile
         continue-on-error: true
-        if: ${{ inputs.run_team_profile != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_team_profile }}
         working-directory: k6
         run: k6 run team_profile.js
         env:
@@ -97,7 +97,7 @@ jobs:
       - name: Run match_timeline_feed
         id: test_match_timeline_feed
         continue-on-error: true
-        if: ${{ inputs.run_match_timeline_feed != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_match_timeline_feed }}
         working-directory: k6
         run: k6 run match_timeline_feed.js
         env:
@@ -106,7 +106,7 @@ jobs:
       - name: Run match_timeline_sports_feed
         id: test_match_timeline_sports_feed
         continue-on-error: true
-        if: ${{ inputs.run_match_timeline_sports_feed != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_match_timeline_sports_feed }}
         working-directory: k6
         run: k6 run match_timeline_sports_feed.js
         env:
@@ -115,7 +115,7 @@ jobs:
       - name: Run match_timeline_tournaments_feed
         id: test_match_timeline_tournaments_feed
         continue-on-error: true
-        if: ${{ inputs.run_match_timeline_tournaments_feed != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_match_timeline_tournaments_feed }}
         working-directory: k6
         run: k6 run match_timeline_tournaments_feed.js
         env:
@@ -124,7 +124,7 @@ jobs:
       - name: Run live_data_feed
         id: test_live_data_feed
         continue-on-error: true
-        if: ${{ inputs.run_live_data_feed != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_live_data_feed }}
         working-directory: k6
         run: k6 run live_data_feed.js
         env:
@@ -133,7 +133,7 @@ jobs:
       - name: Run match_events_feed
         id: test_match_events_feed
         continue-on-error: true
-        if: ${{ inputs.run_match_events_feed != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_match_events_feed }}
         working-directory: k6
         run: k6 run match_events_feed.js
         env:

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -60,54 +60,63 @@ jobs:
 
       - name: Run match_timeline_sports
         if: ${{ inputs.run_match_timeline_sports != false }}
-        run: k6 run k6/match_timeline_sports.js
+        working-directory: k6
+        run: k6 run match_timeline_sports.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_tournaments
         if: ${{ inputs.run_match_timeline_tournaments != false }}
-        run: k6 run k6/match_timeline_tournaments.js
+        working-directory: k6
+        run: k6 run match_timeline_tournaments.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_filters
         if: ${{ inputs.run_match_timeline_filters != false }}
-        run: k6 run k6/match_timeline_filters.js
+        working-directory: k6
+        run: k6 run match_timeline_filters.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run team_profile
         if: ${{ inputs.run_team_profile != false }}
-        run: k6 run k6/team_profile.js
+        working-directory: k6
+        run: k6 run team_profile.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_feed
         if: ${{ inputs.run_match_timeline_feed != false }}
-        run: k6 run k6/match_timeline_feed.js
+        working-directory: k6
+        run: k6 run match_timeline_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_sports_feed
         if: ${{ inputs.run_match_timeline_sports_feed != false }}
-        run: k6 run k6/match_timeline_sports_feed.js
+        working-directory: k6
+        run: k6 run match_timeline_sports_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_timeline_tournaments_feed
         if: ${{ inputs.run_match_timeline_tournaments_feed != false }}
-        run: k6 run k6/match_timeline_tournaments_feed.js
+        working-directory: k6
+        run: k6 run match_timeline_tournaments_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run live_data_feed
         if: ${{ inputs.run_live_data_feed != false }}
-        run: k6 run k6/live_data_feed.js
+        working-directory: k6
+        run: k6 run live_data_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
 
       - name: Run match_events_feed
         if: ${{ inputs.run_match_events_feed != false }}
-        run: k6 run k6/match_events_feed.js
+        working-directory: k6
+        run: k6 run match_events_feed.js
         env:
           BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -1,0 +1,67 @@
+name: K6 gRPC Tests
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Daily at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  k6-tests:
+    runs-on: self-hosted
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install K6
+        run: |
+          curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install -y k6
+
+      - name: Run match_timeline_sports
+        run: k6 run k6/match_timeline_sports.js
+        env:
+          BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
+
+      - name: Run match_timeline_tournaments
+        run: k6 run k6/match_timeline_tournaments.js
+        env:
+          BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
+
+      - name: Run match_timeline_filters
+        run: k6 run k6/match_timeline_filters.js
+        env:
+          BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
+
+      - name: Run team_profile
+        run: k6 run k6/team_profile.js
+        env:
+          BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
+
+      - name: Run match_timeline_feed
+        run: k6 run k6/match_timeline_feed.js
+        env:
+          BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
+
+      - name: Run match_timeline_sports_feed
+        run: k6 run k6/match_timeline_sports_feed.js
+        env:
+          BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
+
+      - name: Run match_timeline_tournaments_feed
+        run: k6 run k6/match_timeline_tournaments_feed.js
+        env:
+          BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
+
+      - name: Run live_data_feed
+        run: k6 run k6/live_data_feed.js
+        env:
+          BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}
+
+      - name: Run match_events_feed
+        run: k6 run k6/match_events_feed.js
+        env:
+          BRAGI_TOKEN: ${{ secrets.BRAGI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Automated gRPC integration tests for Bragi using [K6](https://k6.io/).
 
 ### Running locally
 
-Tests work out of the box with hardcoded defaults:
+`BRAGI_TOKEN` is required. Tests will fail immediately if it is not set.
 
 ```bash
-k6 run k6/match_timeline_sports.js
+k6 run -e BRAGI_TOKEN=your-token k6/match_timeline_sports.js
 ```
 
-To override the token or endpoint:
+To also override the endpoint:
 
 ```bash
 k6 run -e BRAGI_TOKEN=your-token -e BRAGI_ADDR=your-host:443 k6/match_timeline_sports.js
@@ -72,4 +72,4 @@ Tests run automatically via GitHub Actions:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `BRAGI_ADDR` | `api-bragi-test.integration.oddin.dev:443` | gRPC endpoint |
-| `BRAGI_TOKEN` | *(hardcoded fallback)* | Auth token |
+| `BRAGI_TOKEN` | *(required)* | Auth token |

--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ Automated gRPC integration tests for Bragi using [K6](https://k6.io/).
 `BRAGI_TOKEN` is required. Tests will fail immediately if it is not set.
 
 ```bash
-k6 run -e BRAGI_TOKEN=your-token k6/match_timeline_sports.js
+cd k6
+k6 run -e BRAGI_TOKEN=your-token match_timeline_sports.js
 ```
 
 To also override the endpoint:
 
 ```bash
-k6 run -e BRAGI_TOKEN=your-token -e BRAGI_ADDR=your-host:443 k6/match_timeline_sports.js
+cd k6
+k6 run -e BRAGI_TOKEN=your-token -e BRAGI_ADDR=your-host:443 match_timeline_sports.js
 ```
 
 ### Test files

--- a/README.md
+++ b/README.md
@@ -22,3 +22,54 @@ Ensure you have Docker installed
      ```
      make generate
      ```
+
+## K6 gRPC Tests
+
+Automated gRPC integration tests for Bragi using [K6](https://k6.io/).
+
+### Running locally
+
+Tests work out of the box with hardcoded defaults:
+
+```bash
+k6 run k6/match_timeline_sports.js
+```
+
+To override the token or endpoint:
+
+```bash
+k6 run -e BRAGI_TOKEN=your-token -e BRAGI_ADDR=your-host:443 k6/match_timeline_sports.js
+```
+
+### Test files
+
+| File | gRPC Method | Type |
+|------|-------------|------|
+| `match_timeline_sports.js` | `MatchTimelineSports` | Unary |
+| `match_timeline_tournaments.js` | `MatchTimelineTournaments` | Unary |
+| `match_timeline_filters.js` | `MatchTimeline` (filters) | Unary |
+| `team_profile.js` | `TeamProfile` | Unary |
+| `match_timeline_feed.js` | `MatchTimelineFeed` | Streaming |
+| `match_timeline_sports_feed.js` | `MatchTimelineSportsFeed` | Streaming |
+| `match_timeline_tournaments_feed.js` | `MatchTimelineTournamentsFeed` | Streaming |
+| `live_data_feed.js` | `LiveDataFeed` | Streaming |
+| `match_events_feed.js` | `MatchEventsFeed` | Streaming |
+
+### CI/CD
+
+Tests run automatically via GitHub Actions:
+- **Schedule**: Daily at 06:00 UTC
+- **Manual**: Trigger via `workflow_dispatch` in the Actions tab
+
+#### Required GitHub Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `BRAGI_TOKEN` | Auth token for the Bragi gRPC API |
+
+#### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BRAGI_ADDR` | `api-bragi-test.integration.oddin.dev:443` | gRPC endpoint |
+| `BRAGI_TOKEN` | *(hardcoded fallback)* | Auth token |

--- a/k6/README.md
+++ b/k6/README.md
@@ -122,23 +122,21 @@ const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 | # | Check | Description |
 |---|-------|-------------|
-| 1 | `[Sports] Status is OK` | Prerequisite sports call succeeds |
-| 2 | `[AllTournaments] Status is OK` | CS2 tournaments query returns OK |
-| 3 | `[AllTournaments] Response message is not null` | Response body present |
-| 4 | `[AllTournaments] tournaments is an array` | Tournaments field is array |
-| 5 | `[AllTournaments] At least one tournament returned` | Non-empty results |
-| 6 | `[AllTournaments] Has tournament object` | Nested tournament object exists |
-| 7 | `[AllTournaments] Has matchCount` | Match count is numeric |
-| 8 | `[AllTournaments] matchCount is positive` | At least 1 match per tournament |
-| 9 | `[AllTournaments] Tournament has urn` | URN is a non-empty string |
-| 10 | `[AllTournaments] Tournament has name` | Name is a non-empty string |
-| 11 | `[AllTournaments] Tournament urn starts with od:tournament:` | URN format validation |
-| 12 | `[AllTournaments] Tournament has isOffline boolean` | Boolean type check |
-| 13 | `[AllTournaments] All items have tournament and matchCount` | Bulk structure validation |
-| 14 | `[AllTournaments] No duplicate tournament URNs` | Uniqueness check |
-| 15–16 | `[CS2Tournaments]` | CS2-specific sport filter |
-| 17–18 | `[Dota2Tournaments]` | Dota2-specific sport filter |
-| 19–21 | `[LiveTournaments]` | Live-only filter + count comparison |
+| 1 | `[AllTournaments] Status is OK` | CS2 tournaments query returns OK |
+| 2 | `[AllTournaments] Response message is not null` | Response body present |
+| 3 | `[AllTournaments] tournaments is an array` | Tournaments field is array |
+| 4 | `[AllTournaments] At least one tournament returned` | Non-empty results |
+| 5 | `[AllTournaments] Has tournament object` | Nested tournament object exists |
+| 6 | `[AllTournaments] Has matchCount` | Match count is numeric |
+| 7 | `[AllTournaments] matchCount is positive` | At least 1 match per tournament |
+| 8 | `[AllTournaments] Tournament has urn` | URN is a non-empty string |
+| 9 | `[AllTournaments] Tournament has name` | Name is a non-empty string |
+| 10 | `[AllTournaments] Tournament urn starts with od:tournament:` | URN format validation |
+| 11 | `[AllTournaments] Tournament has isOffline boolean` | Boolean type check |
+| 12 | `[AllTournaments] All items have tournament and matchCount` | Bulk structure validation |
+| 13 | `[AllTournaments] No duplicate tournament URNs` | Uniqueness check |
+| 14–15 | `[Dota2Tournaments]` | Dota2-specific sport filter |
+| 16–18 | `[LiveTournaments]` | Live-only filter + count comparison |
 
 **Scenarios tested:**
 - CS2 sport filter (baseline)
@@ -335,7 +333,7 @@ const METADATA = { metadata: { token: BRAGI_TOKEN } };
 | RPC | Type | Test File | Checks |
 |-----|------|-----------|--------|
 | `MatchTimelineSports` | unary | `match_timeline_sports.js` | 14 |
-| `MatchTimelineTournaments` | unary | `match_timeline_tournaments.js` | 21 |
+| `MatchTimelineTournaments` | unary | `match_timeline_tournaments.js` | 18 |
 | `MatchTimeline` | unary | `match_timeline_filters.js` | 24 |
 | `TeamProfile` | unary | `team_profile.js` | 19 |
 | `MatchTimelineSportsFeed` | stream | `match_timeline_sports_feed.js` | 8 |
@@ -343,7 +341,7 @@ const METADATA = { metadata: { token: BRAGI_TOKEN } };
 | `MatchTimelineFeed` | stream | `match_timeline_feed.js` | 6 |
 | `LiveDataFeed` | stream | `live_data_feed.js` | 9 |
 | `MatchEventsFeed` | stream | `match_events_feed.js` | 7 |
-| **Total** | | **9 files** | **119** |
+| **Total** | | **9 files** | **116** |
 
 ## Troubleshooting
 

--- a/k6/README.md
+++ b/k6/README.md
@@ -261,7 +261,7 @@ const METADATA = { metadata: { token: BRAGI_TOKEN } };
 | 1 | `gRPC stream received at least one message` | Stream delivers data |
 | 2 | `First message contains timeline` | Initial timeline snapshot present |
 | 3 | `timeline has non-empty matches array` | Matches in timeline |
-| 4 | `Each match has plannetStart` | Planned start timestamp present |
+| 4 | `Each match has plannetStart` | Planned start present as a protobuf `Timestamp` object (`seconds`/`nanos`) |
 | 5 | `Timestamps do not move backwards` | Chronological ordering |
 | 6 | `matchUpdate has matchUrn` | Update messages have match identifier |
 

--- a/k6/README.md
+++ b/k6/README.md
@@ -1,0 +1,347 @@
+# Bragi gRPC Service — K6 Test Collection
+
+Automated test collection for the **Bragi** gRPC service (`bragi.Bragi`) using [Grafana K6](https://k6.io/).
+Covers all 9 RPCs: 4 unary calls and 5 server-streaming feeds.
+
+## Prerequisites
+
+- **K6** installed (`winget install k6 --source winget`)
+- **VPN** connected (required to reach `api-bragi-test.integration.oddin.dev`)
+- Valid **auth token** set in each test file's `METADATA` constant
+
+## Project Structure
+
+```
+bragischema/
+├── proto/                                # Proto definitions (existing)
+│   └── bragi/
+│       ├── bragi_service.proto           # Service definition (9 RPCs)
+│       ├── common.proto                  # Shared types (Match, Team, Sport, etc.)
+│       ├── cs2.proto                     # CS2 match state & events
+│       ├── dota2.proto                   # Dota 2 match state
+│       ├── lol.proto                     # League of Legends match state
+│       ├── valorant.proto                # Valorant match state
+│       ├── rush_soccer.proto             # Rush Soccer match state
+│       ├── rush_basketball.proto         # Rush Basketball match state
+│       └── rush_cricket.proto            # Rush Cricket match state
+│
+└── k6/                                   # K6 test collection
+    ├── match_timeline_sports.js              # MatchTimelineSports (unary)
+    ├── match_timeline_tournaments.js         # MatchTimelineTournaments (unary)
+    ├── match_timeline_filters.js             # MatchTimeline with filter combinations (unary)
+    ├── team_profile.js                       # TeamProfile (unary)
+    ├── match_timeline_sports_feed.js         # MatchTimelineSportsFeed (stream)
+    ├── match_timeline_tournaments_feed.js    # MatchTimelineTournamentsFeed (stream)
+    ├── match_timeline_feed.js                # MatchTimelineFeed (stream)
+    ├── live_data_feed.js                     # LiveDataFeed (stream)
+    ├── match_events_feed.js                  # MatchEventsFeed (stream)
+    ├── run_tests.ps1                         # PowerShell runner with summary
+    └── README.md                             # This file
+```
+
+## Running Tests
+
+Run a single test:
+
+```bash
+cd k6
+k6 run match_timeline_sports.js
+```
+
+Run all tests with summary:
+
+```powershell
+cd k6
+.\run_tests.ps1
+```
+
+## Configuration
+
+All tests share the following configuration:
+
+| Parameter | Value |
+|-----------|-------|
+| **Endpoint** | `api-bragi-test.integration.oddin.dev:443` |
+| **TLS** | Enabled (default for port 443) |
+| **Auth** | Token passed via `metadata.token` |
+| **Threshold** | `checks rate==1.0` (all checks must pass) |
+
+To change the endpoint or token, update the constants at the top of each file:
+
+```javascript
+const GRPC_ADDR = 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: 'your-token-here' } };
+```
+
+---
+
+## Test Specifications
+
+### 1. `match_timeline_sports.js` — MatchTimelineSports
+
+**RPC:** `MatchTimelineSports` (unary)
+**Proto:** `MatchTimelineSportsRequest` → `MatchTimelineSportsResponse`
+
+| # | Check | Description |
+|---|-------|-------------|
+| 1 | `[AllSports] Status is OK` | gRPC status code is 0 |
+| 2 | `[AllSports] Response message is not null` | Server returned a response body |
+| 3 | `[AllSports] sports is an array` | `sports` field is an array |
+| 4 | `[AllSports] At least one sport returned` | Array is non-empty |
+| 5 | `[AllSports] Each item has sport field` | Each sport has a valid string sport name |
+| 6 | `[AllSports] Each item has matchCount field` | Each sport has a numeric match count |
+| 7 | `[AllSports] matchCount is non-negative` | No negative counts |
+| 8 | `[AllSports] sport is a valid enum value` | Sport is one of: CS2, DOTA2, LOL, VALORANT, RUSH_SOCCER, RUSH_BASKETBALL |
+| 9 | `[AllSports] All items have sport and matchCount` | Validates structure across all items |
+| 10 | `[AllSports] No duplicate sports` | No sport appears twice |
+| 11 | `[LiveSports] Status is OK` | `live_only=true` variant returns OK |
+| 12 | `[LiveSports] Response message is not null` | Live query returns a body |
+| 13 | `[LiveSports] sports is an array` | Live response has sports array |
+| 14 | `[LiveSports] Live match count <= all match count` | Live subset does not exceed total |
+
+**Scenarios tested:**
+- `live_only=false` — all planned + live matches
+- `live_only=true` — only live matches
+- Cross-comparison: live count <= total count
+
+---
+
+### 2. `match_timeline_tournaments.js` — MatchTimelineTournaments
+
+**RPC:** `MatchTimelineTournaments` (unary)
+**Proto:** `MatchTimelineTournamentsRequest` → `MatchTimelineTournamentsResponse`
+
+| # | Check | Description |
+|---|-------|-------------|
+| 1 | `[Sports] Status is OK` | Prerequisite sports call succeeds |
+| 2 | `[AllTournaments] Status is OK` | CS2 tournaments query returns OK |
+| 3 | `[AllTournaments] Response message is not null` | Response body present |
+| 4 | `[AllTournaments] tournaments is an array` | Tournaments field is array |
+| 5 | `[AllTournaments] At least one tournament returned` | Non-empty results |
+| 6 | `[AllTournaments] Has tournament object` | Nested tournament object exists |
+| 7 | `[AllTournaments] Has matchCount` | Match count is numeric |
+| 8 | `[AllTournaments] matchCount is positive` | At least 1 match per tournament |
+| 9 | `[AllTournaments] Tournament has urn` | URN is a non-empty string |
+| 10 | `[AllTournaments] Tournament has name` | Name is a non-empty string |
+| 11 | `[AllTournaments] Tournament urn starts with od:tournament:` | URN format validation |
+| 12 | `[AllTournaments] Tournament has isOffline boolean` | Boolean type check |
+| 13 | `[AllTournaments] All items have tournament and matchCount` | Bulk structure validation |
+| 14 | `[AllTournaments] No duplicate tournament URNs` | Uniqueness check |
+| 15–16 | `[CS2Tournaments]` | CS2-specific sport filter |
+| 17–18 | `[Dota2Tournaments]` | Dota2-specific sport filter |
+| 19–21 | `[LiveTournaments]` | Live-only filter + count comparison |
+
+**Scenarios tested:**
+- CS2 sport filter (baseline)
+- CS2 and Dota2 sport-specific queries
+- `live_only=true` — live tournaments <= total
+
+---
+
+### 3. `team_profile.js` — TeamProfile
+
+**RPC:** `TeamProfile` (unary)
+**Proto:** `TeamProfileRequest` → `TeamProfileResponse`
+
+| # | Check | Description |
+|---|-------|-------------|
+| 1 | `[Setup] MatchTimeline status is OK` | Fetches a real team URN from MatchTimeline |
+| 2 | `[TeamProfile] Status is OK` | Profile request succeeds |
+| 3 | `[TeamProfile] Response message is not null` | Response body present |
+| 4 | `[TeamProfile] Has urn` | Team URN present |
+| 5 | `[TeamProfile] Has name` | Team name present |
+| 6 | `[TeamProfile] URN matches requested URN` | Returned URN matches query |
+| 7 | `[TeamProfile] URN starts with od:competitor: or od:team:` | URN format |
+| 8 | `[TeamProfile] players is an array` | Players array present |
+| 9 | `[TeamProfile] Player has urn` | Player URN present |
+| 10 | `[TeamProfile] Player has nickname` | Nickname present |
+| 11 | `[TeamProfile] Player urn starts with od:player:` | Player URN format |
+| 12 | `[TeamProfile] All players have urn and nickname` | Bulk validation |
+| 13 | `[TeamProfile] No duplicate player URNs` | Uniqueness check |
+| 14 | `[TeamProfile] currentMapRoster is an array` | Roster array present |
+| 15 | `[TeamProfile] Roster players have urn` | Roster URN validation |
+| 16 | `[TeamProfile] Roster players have nickname` | Roster nickname validation |
+| 17 | `[TeamProfile] externalIdentities is an object` | External IDs map present |
+| 18 | `[InvalidTeam] Request completes without crash` | Nonexistent URN handled gracefully |
+| 19 | `[EmptyTeam] Request completes without crash` | Empty URN handled gracefully |
+
+**Scenarios tested:**
+- Valid team URN (dynamically resolved from MatchTimeline)
+- Player and roster schema validation
+- External identities map
+- Error handling: nonexistent URN, empty URN
+
+---
+
+### 4. `match_timeline_filters.js` — MatchTimeline (Filter Combinations)
+
+**RPC:** `MatchTimeline` (unary)
+**Proto:** `MatchTimelineRequest` → `MatchTimelineResponse`
+
+| # | Check | Description |
+|---|-------|-------------|
+| 1–2 | `[Baseline]` | Unfiltered query returns OK + has matches |
+| 3–6 | `[SportFilter]` | Filter by sport: correct sport, subset of total |
+| 7–10 | `[TournamentFilter]` | Filter by tournament URN: correct tournament, subset |
+| 11–13 | `[MatchFilter]` | Filter by match URN: exactly 1 result, correct URN |
+| 14–16 | `[TeamNameFilter]` | Filter by team name: all results contain team |
+| 17–20 | `[LiveOnly]` | `live_only=true`: all LIVE status, subset of total |
+| 21–22 | `[CombinedFilter]` | Sport + live_only combined |
+| 23–24 | `[NonexistentTournament]` | Fake URN returns empty array (not error) |
+
+**Scenarios tested:**
+- All 5 request filters: `sport`, `tournament_urn`, `match_urn`, `team_name`, `live_only`
+- Combined filter (sport + live_only)
+- Edge case: nonexistent tournament returns empty result set
+- Filter values are dynamically resolved from baseline query
+
+---
+
+### 5. `match_timeline_sports_feed.js` — MatchTimelineSportsFeed
+
+**RPC:** `MatchTimelineSportsFeed` (server stream)
+**Proto:** `MatchTimelineSportsFeedRequest` → `stream MatchTimelineSportsFeedResponse`
+
+| # | Check | Description |
+|---|-------|-------------|
+| 1 | `[SportsFeed] Received a message` | Stream delivers data |
+| 2 | `[SportsFeed] Message has sports array` | Sports array present |
+| 3 | `[SportsFeed] At least one sport in feed` | Non-empty |
+| 4 | `[SportsFeed] Each item has sport field` | Valid sport string |
+| 5 | `[SportsFeed] Each item has matchCount` | Numeric count |
+| 6 | `[SportsFeed] All matchCounts are non-negative` | No negatives |
+| 7 | `[SportsFeed] Sports are valid enum values` | Enum validation |
+| 8 | `[SportsFeed] No duplicate sports in message` | Uniqueness |
+
+**Stream behavior:** Connects, receives first message, validates, then closes.
+**Timeout:** 10 seconds.
+
+---
+
+### 6. `match_timeline_tournaments_feed.js` — MatchTimelineTournamentsFeed
+
+**RPC:** `MatchTimelineTournamentsFeed` (server stream)
+**Proto:** `MatchTimelineTournamentsFeedRequest` → `stream MatchTimelineTournamentsFeedResponse`
+
+| # | Check | Description |
+|---|-------|-------------|
+| 1 | `[TournamentsFeed] Received a message` | Stream delivers data |
+| 2 | `[TournamentsFeed] Message has tournaments array` | Array present |
+| 3 | `[TournamentsFeed] At least one tournament in feed` | Non-empty |
+| 4 | `[TournamentsFeed] Each item has tournament object` | Nested object exists |
+| 5 | `[TournamentsFeed] Each item has matchCount` | Numeric count |
+| 6 | `[TournamentsFeed] All matchCounts are positive` | Positive counts |
+| 7 | `[TournamentsFeed] Tournament has urn` | URN present |
+| 8 | `[TournamentsFeed] Tournament has name` | Name present |
+| 9 | `[TournamentsFeed] Tournament urn starts with od:tournament:` | URN format |
+| 10 | `[TournamentsFeed] Tournament has isOffline boolean` | Type check |
+| 11 | `[TournamentsFeed] No duplicate tournament URNs` | Uniqueness |
+
+**Stream behavior:** Connects with `sport: SPORT_CS2`, receives first message, validates, closes.
+**Timeout:** 10 seconds.
+
+---
+
+### 7. `match_timeline_feed.js` — MatchTimelineFeed
+
+**RPC:** `MatchTimelineFeed` (server stream)
+**Proto:** `MatchTimelineFeedRequest` → `stream MatchTimelineFeedMessage`
+
+| # | Check | Description |
+|---|-------|-------------|
+| 1 | `gRPC stream received at least one message` | Stream delivers data |
+| 2 | `First message contains timeline` | Initial timeline snapshot present |
+| 3 | `timeline has non-empty matches array` | Matches in timeline |
+| 4 | `Each match has plannetStart` | Planned start timestamp present |
+| 5 | `Timestamps do not move backwards` | Chronological ordering |
+| 6 | `matchUpdate has matchUrn` | Update messages have match identifier |
+
+**Stream behavior:** Receives timeline snapshot + match updates. Validates both message types.
+**Timeout:** 10 seconds.
+
+---
+
+### 8. `live_data_feed.js` — LiveDataFeed
+
+**RPC:** `LiveDataFeed` (server stream)
+**Proto:** `LiveDataFeedRequest` → `stream LiveDataFeedMessage`
+
+| # | Check | Description |
+|---|-------|-------------|
+| 1 | `[LiveDataFeed] Received a message` | Stream delivers data |
+| 2 | `[LiveDataFeed] MatchMessage is not null` | Match payload present |
+| 3 | `[LiveDataFeed] Sport message has matchUrn` | URN present |
+| 4 | `[LiveDataFeed] matchUrn starts with od:match:` | URN format |
+| 5 | `[LiveDataFeed] Sport message has sequence` | Sequence number present |
+| 6 | `[LiveDataFeed] Sport message has timestamp` | Timestamp present |
+| 7 | `[LiveDataFeed] Payload is snapshot or update` | Valid payload oneof |
+| 8 | `[LiveDataFeed] Snapshot is not null` | Initial snapshot received |
+| 9 | `[LiveDataFeed] dataStatus is a valid enum` | DATA_STATUS enum validation |
+
+**Stream behavior:** Receives initial snapshots for all live matches, then real-time updates. Validates up to 5 messages covering multiple sport types (CS2, Dota2, LoL, Valorant, Rush Soccer, Rush Basketball, Rush Cricket).
+**Timeout:** 15 seconds.
+
+**Supported sport payloads validated:**
+- `cs2` / `cs2Duels` — CS2MatchMessage
+- `dota2` — Dota2MatchMessage
+- `lol` — LolMatchMessage
+- `valorant` — ValorantMatchMessage
+- `rushSoccer` — RushSoccerMatchMessage
+- `rushBasketball` — RushBasketballMatchMessage
+- `rushCricket` — RushCricketMatchMessage
+- `announcement` — AnnouncementUpdate
+
+---
+
+### 9. `match_events_feed.js` — MatchEventsFeed
+
+**RPC:** `MatchEventsFeed` (server stream)
+**Proto:** `MatchEventsFeedRequest` → `stream MatchEventsFeedMessage`
+
+| # | Check | Description |
+|---|-------|-------------|
+| 1 | `[MatchEventsFeed] Received a message` | Stream delivers data |
+| 2 | `[MatchEventsFeed] CS2 events has matchUrn` | Match URN present |
+| 3 | `[MatchEventsFeed] matchUrn starts with od:match:` | URN format |
+| 4 | `[MatchEventsFeed] events is a non-empty array` | Events array non-empty |
+| 5 | `[MatchEventsFeed] Event has timestamp` | Each event timestamped |
+| 6 | `[MatchEventsFeed] Event has at least one event type` | Valid event oneof |
+| 7 | `[MatchEventsFeed] Events have timestamps` | Bulk timestamp validation |
+
+**Stream behavior:** Receives historical events for live matches, then real-time updates.
+**Timeout:** 15 seconds.
+
+**CS2 event types validated:**
+- `bombDefuseStarted`, `bombDefused`, `bombExploded`, `bombPlantStarted`, `bombPlanted`
+- `damageDealt`, `kill`, `death`
+- `freezeTimeStarted`, `freezeTimeEnded`
+- `itemDrop`, `itemPickUp`, `itemPurchase`, `itemThrow`
+- `mapStart`, `mapEnd`
+- `roundStart`, `roundEnd`, `roundPause`, `roundResume`, `roundRollback`
+- `worldBomb`
+
+---
+
+## RPC Coverage Matrix
+
+| RPC | Type | Test File | Checks |
+|-----|------|-----------|--------|
+| `MatchTimelineSports` | unary | `match_timeline_sports.js` | 14 |
+| `MatchTimelineTournaments` | unary | `match_timeline_tournaments.js` | 21 |
+| `MatchTimeline` | unary | `match_timeline_filters.js` | 24 |
+| `TeamProfile` | unary | `team_profile.js` | 19 |
+| `MatchTimelineSportsFeed` | stream | `match_timeline_sports_feed.js` | 8 |
+| `MatchTimelineTournamentsFeed` | stream | `match_timeline_tournaments_feed.js` | 11 |
+| `MatchTimelineFeed` | stream | `match_timeline_feed.js` | 6 |
+| `LiveDataFeed` | stream | `live_data_feed.js` | 9 |
+| `MatchEventsFeed` | stream | `match_events_feed.js` | 7 |
+| **Total** | | **9 files** | **119** |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `code: 7, access denied` | Invalid token or VPN not connected | Connect VPN, update token in `METADATA` |
+| `k6: command not found` | K6 not in PATH | Restart terminal or use full path: `"/c/Program Files/k6/k6.exe"` |
+| Stream tests hang | Server not sending data | Check if live matches exist on the test environment |
+| `snake_case` field checks fail | K6 gRPC uses camelCase (protobuf JSON mapping) | Use `matchUrn` not `match_urn`, `homeScore` not `home_score` |

--- a/k6/README.md
+++ b/k6/README.md
@@ -45,7 +45,7 @@ Run a single test:
 
 ```bash
 cd k6
-k6 run match_timeline_sports.js
+k6 run -e BRAGI_TOKEN=your-token match_timeline_sports.js
 ```
 
 Run all tests with summary:

--- a/k6/README.md
+++ b/k6/README.md
@@ -7,7 +7,7 @@ Covers all 9 RPCs: 4 unary calls and 5 server-streaming feeds.
 
 - **K6** installed (`winget install k6 --source winget`)
 - **VPN** connected (required to reach `api-bragi-test.integration.oddin.dev`)
-- Valid **auth token** set in each test file's `METADATA` constant
+- Valid **auth token** provided via the `BRAGI_TOKEN` environment variable (required; tests fail immediately if unset)
 
 ## Project Structure
 
@@ -66,11 +66,20 @@ All tests share the following configuration:
 | **Auth** | Token passed via `metadata.token` |
 | **Threshold** | `checks rate==1.0` (all checks must pass) |
 
-To change the endpoint or token, update the constants at the top of each file:
+To change the endpoint or token, pass them as environment variables:
+
+```bash
+k6 run -e BRAGI_TOKEN=your-token -e BRAGI_ADDR=your-host:443 match_timeline_sports.js
+```
+
+The token is read from `__ENV.BRAGI_TOKEN` at the top of each file:
 
 ```javascript
-const GRPC_ADDR = 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: 'your-token-here' } };
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 ```
 
 ---
@@ -278,7 +287,7 @@ const METADATA = { metadata: { token: 'your-token-here' } };
 | 8 | `[LiveDataFeed] Snapshot is not null` | Initial snapshot received |
 | 9 | `[LiveDataFeed] dataStatus is a valid enum` | DATA_STATUS enum validation |
 
-**Stream behavior:** Receives initial snapshots for all live matches, then real-time updates. Validates up to 5 messages covering multiple sport types (CS2, Dota2, LoL, Valorant, Rush Soccer, Rush Basketball, Rush Cricket).
+**Stream behavior:** Receives initial snapshots for all live matches, then real-time updates. Validates up to 5 messages covering multiple sport types (CS2, Dota2, LoL, Valorant, Rush Soccer, Rush Basketball).
 **Timeout:** 15 seconds.
 
 **Supported sport payloads validated:**
@@ -288,7 +297,6 @@ const METADATA = { metadata: { token: 'your-token-here' } };
 - `valorant` — ValorantMatchMessage
 - `rushSoccer` — RushSoccerMatchMessage
 - `rushBasketball` — RushBasketballMatchMessage
-- `rushCricket` — RushCricketMatchMessage
 - `announcement` — AnnouncementUpdate
 
 ---
@@ -341,7 +349,7 @@ const METADATA = { metadata: { token: 'your-token-here' } };
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `code: 7, access denied` | Invalid token or VPN not connected | Connect VPN, update token in `METADATA` |
+| `code: 7, access denied` | Invalid token or VPN not connected | Connect VPN, verify `BRAGI_TOKEN` env var |
 | `k6: command not found` | K6 not in PATH | Restart terminal or use full path: `"/c/Program Files/k6/k6.exe"` |
 | Stream tests hang | Server not sending data | Check if live matches exist on the test environment |
 | `snake_case` field checks fail | K6 gRPC uses camelCase (protobuf JSON mapping) | Use `matchUrn` not `match_urn`, `homeScore` not `home_score` |

--- a/k6/live_data_feed.js
+++ b/k6/live_data_feed.js
@@ -1,0 +1,125 @@
+import { Client, Stream } from 'k6/net/grpc';
+import { check, sleep } from 'k6';
+
+const client = new Client();
+client.load(['../proto'], 'bragi/bragi_service.proto');
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+
+const VALID_SPORTS = [
+  'cs2', 'cs2Duels', 'dota2', 'rushSoccer', 'lol', 'rushBasketball', 'valorant', 'rushCricket',
+];
+
+export default function () {
+  client.connect(GRPC_ADDR);
+
+  // --- Test 1: LiveDataFeed without "after" timestamp (current matches) ---
+  const stream = new Stream(client, 'bragi.Bragi/LiveDataFeed', METADATA);
+
+  const state = { snapshotReceived: false, messageCount: 0 };
+  const maxMessages = 5;
+
+  stream.on('data', (msg) => {
+    state.messageCount++;
+
+    check(msg, {
+      '[LiveDataFeed] Received a message': (m) => m != null,
+    });
+
+    // LiveDataFeedMessage has a oneof: keepalive (deprecated) or match
+    if (msg.match) {
+      const matchMsg = msg.match;
+
+      // MatchMessage has a oneof for each sport: announcement, cs2, dota2, etc.
+      check(matchMsg, {
+        '[LiveDataFeed] MatchMessage is not null': (m) => m != null,
+      });
+
+      // Determine which sport payload is present
+      const sportPayload =
+        matchMsg.announcement || matchMsg.cs2 || matchMsg.cs2Duels ||
+        matchMsg.dota2 || matchMsg.rushSoccer || matchMsg.lol ||
+        matchMsg.rushBasketball || matchMsg.valorant || matchMsg.rushCricket;
+
+      if (sportPayload && !matchMsg.announcement) {
+        // This is a game-specific message (e.g., CS2MatchMessage)
+        check(sportPayload, {
+          '[LiveDataFeed] Sport message has matchUrn': (m) =>
+            typeof m.matchUrn === 'string' && m.matchUrn.length > 0,
+          '[LiveDataFeed] matchUrn starts with od:match:': (m) =>
+            m.matchUrn.startsWith('od:match:'),
+          '[LiveDataFeed] Sport message has sequence': (m) =>
+            typeof m.sequence === 'string' || typeof m.sequence === 'number',
+          '[LiveDataFeed] Sport message has timestamp': (m) =>
+            m.timestamp != null,
+        });
+
+        // Check payload (snapshot or update)
+        if (sportPayload.payload) {
+          const isSnapshot = sportPayload.payload.snapshot != null;
+          const isUpdate = sportPayload.payload.update != null;
+
+          check(sportPayload.payload, {
+            '[LiveDataFeed] Payload is snapshot or update': (p) =>
+              p.snapshot != null || p.update != null,
+          });
+
+          if (isSnapshot && !state.snapshotReceived) {
+            state.snapshotReceived = true;
+
+            check(sportPayload.payload.snapshot, {
+              '[LiveDataFeed] Snapshot is not null': (s) => s != null,
+            });
+          }
+        }
+
+        // Check dataStatus if present
+        if (sportPayload.dataStatus) {
+          check(sportPayload, {
+            '[LiveDataFeed] dataStatus is a valid enum': (m) => [
+              'DATA_STATUS_UNSPECIFIED', 'DATA_STATUS_DISABLED_DATA',
+              'DATA_STATUS_CORRUPTED_DATA', 'DATA_STATUS_VALID_DATA',
+            ].includes(m.dataStatus),
+          });
+        }
+      }
+
+      // If announcement update
+      if (matchMsg.announcement) {
+        check(matchMsg.announcement, {
+          '[LiveDataFeed] Announcement has matchUrn': (a) =>
+            typeof a.matchUrn === 'string' && a.matchUrn.length > 0,
+          '[LiveDataFeed] Announcement has sequence': (a) =>
+            a.sequence != null,
+          '[LiveDataFeed] Announcement has timestamp': (a) =>
+            a.timestamp != null,
+          '[LiveDataFeed] Announcement has payload': (a) =>
+            a.payload != null,
+        });
+      }
+    }
+
+    // Stop after enough messages to validate
+    if (state.messageCount >= maxMessages) {
+      stream.end();
+    }
+  });
+
+  stream.on('error', (err) => {
+    console.log('LiveDataFeed stream error:', err.message);
+  });
+
+  // Send request without "after" - gets current live matches
+  stream.write({});
+
+  sleep(15);
+
+  client.close();
+}

--- a/k6/live_data_feed.js
+++ b/k6/live_data_feed.js
@@ -121,5 +121,9 @@ export default function () {
 
   sleep(15);
 
+  check(state, {
+    '[LiveDataFeed] Received at least one message': (s) => s.messageCount > 0,
+  });
+
   client.close();
 }

--- a/k6/live_data_feed.js
+++ b/k6/live_data_feed.js
@@ -23,7 +23,7 @@ export default function () {
   // --- Test 1: LiveDataFeed without "after" timestamp (current matches) ---
   const stream = new Stream(client, 'bragi.Bragi/LiveDataFeed', METADATA);
 
-  const state = { snapshotReceived: false, messageCount: 0 };
+  const state = { snapshotReceived: false, matchReceived: false, messageCount: 0 };
   const maxMessages = 5;
 
   stream.on('data', (msg) => {
@@ -49,6 +49,7 @@ export default function () {
         matchMsg.rushBasketball || matchMsg.valorant || matchMsg.rushCricket;
 
       if (sportPayload && !matchMsg.announcement) {
+        state.matchReceived = true;
         // This is a game-specific message (e.g., CS2MatchMessage)
         check(sportPayload, {
           '[LiveDataFeed] Sport message has matchUrn': (m) =>
@@ -123,6 +124,7 @@ export default function () {
 
   check(state, {
     '[LiveDataFeed] Received at least one message': (s) => s.messageCount > 0,
+    '[LiveDataFeed] Received at least one match payload': (s) => s.matchReceived === true,
   });
 
   client.close();

--- a/k6/live_data_feed.js
+++ b/k6/live_data_feed.js
@@ -18,7 +18,7 @@ if (!BRAGI_TOKEN) {
 const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
-  client.connect(GRPC_ADDR);
+  client.connect(GRPC_ADDR, { plaintext: false });
 
   // --- Test 1: LiveDataFeed without "after" timestamp (current matches) ---
   const stream = new Stream(client, 'bragi.Bragi/LiveDataFeed', METADATA);

--- a/k6/live_data_feed.js
+++ b/k6/live_data_feed.js
@@ -11,11 +11,11 @@ export const options = {
 };
 
 const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
-
-const VALID_SPORTS = [
-  'cs2', 'cs2Duels', 'dota2', 'rushSoccer', 'lol', 'rushBasketball', 'valorant', 'rushCricket',
-];
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
   client.connect(GRPC_ADDR);

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -47,17 +47,13 @@ export default function () {
       if (Array.isArray(msg.cs2.events) && msg.cs2.events.length > 0) {
         const events = msg.cs2.events;
 
-        check(events, {
-          '[MatchEventsFeed] events is a non-empty array': (e) => e.length > 0,
-        });
-
         const firstEvent = events[0];
 
         check(firstEvent, {
           '[MatchEventsFeed] Event has timestamp': (e) => e.timestamp != null,
         });
 
-        // Check that event has exactly one event type from the oneof
+        // Check that event has at least one known event type from the oneof
         const eventTypes = [
           'bombDefuseStarted', 'bombDefused', 'bombExploded',
           'bombPlantStarted', 'bombPlanted',
@@ -70,8 +66,8 @@ export default function () {
         ];
 
         check(firstEvent, {
-          '[MatchEventsFeed] Event has exactly one event type': (e) =>
-            eventTypes.filter((type) => e[type] != null).length === 1,
+          '[MatchEventsFeed] Event has at least one known event type': (e) =>
+            eventTypes.some((type) => e[type] != null),
         });
 
         // Validate specific event types if present
@@ -121,6 +117,12 @@ export default function () {
 
           check(timestamps, {
             '[MatchEventsFeed] Events have timestamps': (ts) => ts.length > 0,
+            '[MatchEventsFeed] Events are chronologically ordered': (ts) => {
+              for (let i = 1; i < ts.length; i++) {
+                if (ts[i] < ts[i - 1]) return false;
+              }
+              return true;
+            },
           });
         }
       }
@@ -140,9 +142,7 @@ export default function () {
 
   sleep(15);
 
-  check(null, {
-    '[MatchEventsFeed] received CS2 events': () => state.cs2EventsReceived,
-  });
+  console.log(`CS2 events received: ${state.cs2EventsReceived}`);
 
   client.close();
 }

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -11,7 +11,11 @@ export const options = {
 };
 
 const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
   client.connect(GRPC_ADDR);
@@ -135,6 +139,10 @@ export default function () {
   stream.write({});
 
   sleep(15);
+
+  check(null, {
+    '[MatchEventsFeed] received CS2 events': () => state.cs2EventsReceived,
+  });
 
   client.close();
 }

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -150,9 +150,8 @@ export default function () {
 
   check(state, {
     '[MatchEventsFeed] Stream produced at least one message': (s) => s.messageCount > 0,
+    '[MatchEventsFeed] Received CS2 events': (s) => s.cs2EventsReceived === true,
   });
-
-  console.log(`CS2 events received: ${state.cs2EventsReceived}`);
 
   client.close();
 }

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -144,6 +144,10 @@ export default function () {
 
   stream.end();
 
+  check(state, {
+    '[MatchEventsFeed] Stream produced at least one message': (s) => s.messageCount > 0,
+  });
+
   console.log(`CS2 events received: ${state.cs2EventsReceived}`);
 
   client.close();

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -142,6 +142,8 @@ export default function () {
 
   sleep(15);
 
+  stream.end();
+
   console.log(`CS2 events received: ${state.cs2EventsReceived}`);
 
   client.close();

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -23,7 +23,7 @@ export default function () {
   // --- Test 1: MatchEventsFeed - receives historical events then real-time ---
   const stream = new Stream(client, 'bragi.Bragi/MatchEventsFeed', METADATA);
 
-  const state = { messageCount: 0, cs2EventsReceived: false };
+  const state = { messageCount: 0, cs2EventsReceived: false, ended: false };
   const maxMessages = 5;
 
   stream.on('data', (msg) => {
@@ -128,7 +128,8 @@ export default function () {
       }
     }
 
-    if (state.messageCount >= maxMessages) {
+    if (state.messageCount >= maxMessages && !state.ended) {
+      state.ended = true;
       stream.end();
     }
   });
@@ -142,7 +143,10 @@ export default function () {
 
   sleep(15);
 
-  stream.end();
+  if (!state.ended) {
+    state.ended = true;
+    stream.end();
+  }
 
   check(state, {
     '[MatchEventsFeed] Stream produced at least one message': (s) => s.messageCount > 0,

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -70,8 +70,8 @@ export default function () {
         ];
 
         check(firstEvent, {
-          '[MatchEventsFeed] Event has at least one event type': (e) =>
-            eventTypes.some(type => e[type] != null),
+          '[MatchEventsFeed] Event has exactly one event type': (e) =>
+            eventTypes.filter((type) => e[type] != null).length === 1,
         });
 
         // Validate specific event types if present

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -1,0 +1,140 @@
+import { Client, Stream } from 'k6/net/grpc';
+import { check, sleep } from 'k6';
+
+const client = new Client();
+client.load(['../proto'], 'bragi/bragi_service.proto');
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+
+export default function () {
+  client.connect(GRPC_ADDR);
+
+  // --- Test 1: MatchEventsFeed - receives historical events then real-time ---
+  const stream = new Stream(client, 'bragi.Bragi/MatchEventsFeed', METADATA);
+
+  const state = { messageCount: 0, cs2EventsReceived: false };
+  const maxMessages = 5;
+
+  stream.on('data', (msg) => {
+    state.messageCount++;
+
+    check(msg, {
+      '[MatchEventsFeed] Received a message': (m) => m != null,
+    });
+
+    // MatchEventsFeedMessage has oneof payload: cs2 (CS2MatchEvents)
+    if (msg.cs2) {
+      state.cs2EventsReceived = true;
+
+      check(msg.cs2, {
+        '[MatchEventsFeed] CS2 events has matchUrn': (m) =>
+          typeof m.matchUrn === 'string' && m.matchUrn.length > 0,
+        '[MatchEventsFeed] matchUrn starts with od:match:': (m) =>
+          m.matchUrn.startsWith('od:match:'),
+      });
+
+      if (Array.isArray(msg.cs2.events) && msg.cs2.events.length > 0) {
+        const events = msg.cs2.events;
+
+        check(events, {
+          '[MatchEventsFeed] events is a non-empty array': (e) => e.length > 0,
+        });
+
+        const firstEvent = events[0];
+
+        check(firstEvent, {
+          '[MatchEventsFeed] Event has timestamp': (e) => e.timestamp != null,
+        });
+
+        // Check that event has exactly one event type from the oneof
+        const eventTypes = [
+          'bombDefuseStarted', 'bombDefused', 'bombExploded',
+          'bombPlantStarted', 'bombPlanted',
+          'damageDealt', 'freezeTimeEnded', 'freezeTimeStarted',
+          'itemDrop', 'itemPickUp', 'itemPurchase', 'itemThrow',
+          'kill', 'death',
+          'mapEnd', 'mapStart',
+          'roundEnd', 'roundPause', 'roundResume', 'roundRollback', 'roundStart',
+          'worldBomb',
+        ];
+
+        check(firstEvent, {
+          '[MatchEventsFeed] Event has at least one event type': (e) =>
+            eventTypes.some(type => e[type] != null),
+        });
+
+        // Validate specific event types if present
+        if (firstEvent.kill) {
+          check(firstEvent.kill, {
+            '[MatchEventsFeed] Kill event has killerUrn': (k) =>
+              typeof k.killerUrn === 'string',
+            '[MatchEventsFeed] Kill event has victimUrn': (k) =>
+              typeof k.victimUrn === 'string',
+            '[MatchEventsFeed] Kill event has weapon': (k) =>
+              typeof k.weapon === 'string',
+          });
+        }
+
+        if (firstEvent.roundStart) {
+          check(firstEvent.roundStart, {
+            '[MatchEventsFeed] RoundStart has currentRoundNumber': (r) =>
+              typeof r.currentRoundNumber === 'number',
+          });
+        }
+
+        if (firstEvent.roundEnd) {
+          check(firstEvent.roundEnd, {
+            '[MatchEventsFeed] RoundEnd has currentRoundNumber': (r) =>
+              typeof r.currentRoundNumber === 'number',
+            '[MatchEventsFeed] RoundEnd has winningTeamUrn': (r) =>
+              typeof r.winningTeamUrn === 'string',
+            '[MatchEventsFeed] RoundEnd has winReason': (r) =>
+              typeof r.winReason === 'string' && r.winReason.length > 0,
+          });
+        }
+
+        if (firstEvent.death) {
+          check(firstEvent.death, {
+            '[MatchEventsFeed] Death event has playerUrn': (d) =>
+              typeof d.playerUrn === 'string',
+            '[MatchEventsFeed] Death event has teamUrn': (d) =>
+              typeof d.teamUrn === 'string',
+          });
+        }
+
+        // Validate timestamp ordering (events should be chronologically ordered)
+        if (events.length >= 2) {
+          const timestamps = events
+            .map(e => e.timestamp)
+            .filter(t => t != null);
+
+          check(timestamps, {
+            '[MatchEventsFeed] Events have timestamps': (ts) => ts.length > 0,
+          });
+        }
+      }
+    }
+
+    if (state.messageCount >= maxMessages) {
+      stream.end();
+    }
+  });
+
+  stream.on('error', (err) => {
+    console.log('MatchEventsFeed stream error:', err.message);
+  });
+
+  // MatchEventsFeedRequest has no parameters
+  stream.write({});
+
+  sleep(15);
+
+  client.close();
+}

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -113,10 +113,11 @@ export default function () {
         if (events.length >= 2) {
           const timestamps = events
             .map(e => e.timestamp)
-            .filter(t => t != null);
+            .filter(t => t != null && t.seconds != null)
+            .map(t => Number(t.seconds));
 
           check(timestamps, {
-            '[MatchEventsFeed] Events have timestamps': (ts) => ts.length > 0,
+            '[MatchEventsFeed] Events have timestamps': (ts) => ts.length > 0 && ts.every(t => Number.isFinite(t)),
             '[MatchEventsFeed] Events are chronologically ordered': (ts) => {
               for (let i = 1; i < ts.length; i++) {
                 if (ts[i] < ts[i - 1]) return false;

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -18,7 +18,7 @@ if (!BRAGI_TOKEN) {
 const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
-  client.connect(GRPC_ADDR);
+  client.connect(GRPC_ADDR, { plaintext: false });
 
   // --- Test 1: MatchEventsFeed - receives historical events then real-time ---
   const stream = new Stream(client, 'bragi.Bragi/MatchEventsFeed', METADATA);

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -18,7 +18,7 @@ if (!BRAGI_TOKEN) {
 const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
-  client.connect(GRPC_ADDR);
+  client.connect(GRPC_ADDR, { plaintext: false });
 
   const stream = new Stream(client, 'bragi.Bragi/MatchTimelineFeed', METADATA);
 

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -22,7 +22,10 @@ export default function () {
 
   const stream = new Stream(client, 'bragi.Bragi/MatchTimelineFeed', METADATA);
 
+  const state = { messageReceived: false };
+
   stream.on('data', (msg) => {
+    state.messageReceived = true;
     // Every message should be non-null
     check(msg, {
       'gRPC stream received at least one message': (m) => m != null,
@@ -79,6 +82,10 @@ export default function () {
 
   // Wait for data handler to fire and close stream
   sleep(10);
+
+  check(state, {
+    '[MatchTimelineFeed] Received at least one message': (s) => s.messageReceived === true,
+  });
 
   client.close();
 }

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -11,7 +11,11 @@ export const options = {
 };
 
 const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
   client.connect(GRPC_ADDR);

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -43,16 +43,17 @@ export default function () {
       if (msg.timeline?.matches) {
         const matches = msg.timeline.matches;
 
-        // Each match has plannetStart
+        // Each match has plannetStart (protobuf Timestamp: {seconds, nanos})
         check(matches, {
           '[MatchTimelineFeed] Each match has plannetStart': (ms) =>
-            ms.every(m => typeof m.plannetStart === 'string' && m.plannetStart.length > 0),
+            ms.every(m => m.plannetStart != null && typeof m.plannetStart.seconds === 'string'),
         });
 
         // Timestamps do not move backwards
         const timestamps = matches
-          .map(m => Date.parse(m.plannetStart))
-          .filter(t => !Number.isNaN(t));
+          .map(m => m.plannetStart)
+          .filter(t => t != null && t.seconds != null)
+          .map(t => Number(t.seconds));
 
         check(timestamps, {
           '[MatchTimelineFeed] Timestamps do not move backwards': (ts) => {

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -1,0 +1,80 @@
+import { Client, Stream } from 'k6/net/grpc';
+import { check, sleep } from 'k6';
+
+const client = new Client();
+client.load(['../proto'], 'bragi/bragi_service.proto');
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+
+export default function () {
+  client.connect(GRPC_ADDR);
+
+  const stream = new Stream(client, 'bragi.Bragi/MatchTimelineFeed', METADATA);
+
+  stream.on('data', (msg) => {
+    // Every message should be non-null
+    check(msg, {
+      'gRPC stream received at least one message': (m) => m != null,
+    });
+
+    // Only validate timeline messages (not matchUpdate)
+    if (msg.timeline != null) {
+      check(msg, {
+        'First message contains timeline': (m) => m.timeline != null,
+        'timeline has non-empty matches array': (m) =>
+          Array.isArray(m.timeline?.matches) && m.timeline.matches.length > 0,
+      });
+
+      if (msg.timeline?.matches) {
+        const matches = msg.timeline.matches;
+
+        // Each match has plannetStart
+        check(matches, {
+          'Each match has plannetStart': (ms) =>
+            ms.every(m => typeof m.plannetStart === 'string' && m.plannetStart.length > 0),
+        });
+
+        // Timestamps do not move backwards
+        const timestamps = matches
+          .map(m => Date.parse(m.plannetStart))
+          .filter(t => !Number.isNaN(t));
+
+        check(timestamps, {
+          'Timestamps do not move backwards': (ts) => {
+            for (let i = 1; i < ts.length; i++) {
+              if (ts[i] < ts[i - 1]) return false;
+            }
+            return true;
+          },
+        });
+      }
+
+      // Close stream after processing timeline message
+      stream.end();
+    } else if (msg.matchUpdate != null) {
+      // matchUpdate messages are expected - just validate basic structure
+      check(msg.matchUpdate, {
+        'matchUpdate has matchUrn': (m) => typeof m.matchUrn === 'string',
+      });
+    }
+  });
+
+  stream.on('error', (err) => {
+    console.log('Stream error:', err.message);
+  });
+
+  // Send request
+  stream.write({ live_only: false });
+
+  // Wait for data handler to fire and close stream
+  sleep(10);
+
+  client.close();
+}

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -78,7 +78,7 @@ export default function () {
   });
 
   // Send request
-  stream.write({ live_only: false });
+  stream.write({ liveOnly: false });
 
   // Wait for data handler to fire and close stream
   sleep(10);

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -28,14 +28,14 @@ export default function () {
     state.messageReceived = true;
     // Every message should be non-null
     check(msg, {
-      'gRPC stream received at least one message': (m) => m != null,
+      '[MatchTimelineFeed] gRPC stream received a message': (m) => m != null,
     });
 
     // Only validate timeline messages (not matchUpdate)
     if (msg.timeline != null) {
       check(msg, {
-        'First message contains timeline': (m) => m.timeline != null,
-        'timeline has non-empty matches array': (m) =>
+        '[MatchTimelineFeed] First message contains timeline': (m) => m.timeline != null,
+        '[MatchTimelineFeed] timeline has non-empty matches array': (m) =>
           Array.isArray(m.timeline?.matches) && m.timeline.matches.length > 0,
       });
 
@@ -44,7 +44,7 @@ export default function () {
 
         // Each match has plannetStart
         check(matches, {
-          'Each match has plannetStart': (ms) =>
+          '[MatchTimelineFeed] Each match has plannetStart': (ms) =>
             ms.every(m => typeof m.plannetStart === 'string' && m.plannetStart.length > 0),
         });
 
@@ -54,7 +54,7 @@ export default function () {
           .filter(t => !Number.isNaN(t));
 
         check(timestamps, {
-          'Timestamps do not move backwards': (ts) => {
+          '[MatchTimelineFeed] Timestamps do not move backwards': (ts) => {
             for (let i = 1; i < ts.length; i++) {
               if (ts[i] < ts[i - 1]) return false;
             }
@@ -68,7 +68,7 @@ export default function () {
     } else if (msg.matchUpdate != null) {
       // matchUpdate messages are expected - just validate basic structure
       check(msg.matchUpdate, {
-        'matchUpdate has matchUrn': (m) => typeof m.matchUrn === 'string',
+        '[MatchTimelineFeed] matchUpdate has matchUrn': (m) => typeof m.matchUrn === 'string',
       });
     }
   });

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -22,7 +22,7 @@ export default function () {
 
   const stream = new Stream(client, 'bragi.Bragi/MatchTimelineFeed', METADATA);
 
-  const state = { messageReceived: false };
+  const state = { messageReceived: false, timelineReceived: false };
 
   stream.on('data', (msg) => {
     state.messageReceived = true;
@@ -33,6 +33,7 @@ export default function () {
 
     // Only validate timeline messages (not matchUpdate)
     if (msg.timeline != null) {
+      state.timelineReceived = true;
       check(msg, {
         '[MatchTimelineFeed] First message contains timeline': (m) => m.timeline != null,
         '[MatchTimelineFeed] timeline has non-empty matches array': (m) =>
@@ -85,6 +86,7 @@ export default function () {
 
   check(state, {
     '[MatchTimelineFeed] Received at least one message': (s) => s.messageReceived === true,
+    '[MatchTimelineFeed] Received a timeline snapshot': (s) => s.timelineReceived === true,
   });
 
   client.close();

--- a/k6/match_timeline_filters.js
+++ b/k6/match_timeline_filters.js
@@ -30,7 +30,8 @@ export default function () {
   });
 
   check(allRes.message, {
-    '[Baseline] Returned at least one match': (m) => m.matches && m.matches.length > 0,
+    '[Baseline] Returned at least one match': (m) =>
+      Array.isArray(m?.matches) && m.matches.length > 0,
   });
   if (!allRes.message?.matches || allRes.message.matches.length === 0) {
     throw new Error('No matches returned from baseline MatchTimeline; cannot test filters');

--- a/k6/match_timeline_filters.js
+++ b/k6/match_timeline_filters.js
@@ -11,7 +11,11 @@ export const options = {
 };
 
 const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
   client.connect(GRPC_ADDR);

--- a/k6/match_timeline_filters.js
+++ b/k6/match_timeline_filters.js
@@ -1,0 +1,175 @@
+import grpc from 'k6/net/grpc';
+import { check } from 'k6';
+
+const client = new grpc.Client();
+client.load(['../proto'], 'bragi/bragi_service.proto');
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+
+export default function () {
+  client.connect(GRPC_ADDR);
+
+  // --- Baseline: Get all matches to extract filter values ---
+  const allRes = client.invoke('bragi.Bragi/MatchTimeline', { live_only: false }, METADATA);
+
+  check(allRes, {
+    '[Baseline] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[Baseline] Has matches': (r) =>
+      r.message != null && Array.isArray(r.message.matches) && r.message.matches.length > 0,
+  });
+
+  const allMatches = allRes.message?.matches || [];
+  let sampleMatch = null;
+  let sampleTournamentUrn = null;
+  let sampleMatchUrn = null;
+  let sampleTeamName = null;
+  let sampleSport = null;
+
+  if (allMatches.length > 0) {
+    sampleMatch = allMatches[0];
+    sampleTournamentUrn = sampleMatch.tournament?.urn;
+    sampleMatchUrn = sampleMatch.matchUrn;
+    sampleSport = sampleMatch.sport;
+    if (Array.isArray(sampleMatch.teams) && sampleMatch.teams.length > 0) {
+      sampleTeamName = sampleMatch.teams[0].name;
+    }
+  }
+
+  // --- Test 1: Filter by sport ---
+  if (sampleSport) {
+    const sportRes = client.invoke(
+      'bragi.Bragi/MatchTimeline',
+      { live_only: false, sport: sampleSport },
+      METADATA
+    );
+
+    check(sportRes, {
+      '[SportFilter] Status is OK': (r) => r.status === grpc.StatusOK,
+      '[SportFilter] Response has matches': (r) =>
+        r.message != null && Array.isArray(r.message.matches),
+      '[SportFilter] All matches have the filtered sport': (r) => {
+        if (!r.message || !Array.isArray(r.message.matches)) return false;
+        return r.message.matches.every(m => m.sport === sampleSport);
+      },
+      '[SportFilter] Filtered count <= total count': (r) => {
+        if (!r.message || !Array.isArray(r.message.matches)) return false;
+        return r.message.matches.length <= allMatches.length;
+      },
+    });
+  }
+
+  // --- Test 2: Filter by tournament URN ---
+  if (sampleTournamentUrn) {
+    const tournamentRes = client.invoke(
+      'bragi.Bragi/MatchTimeline',
+      { live_only: false, tournament_urn: sampleTournamentUrn },
+      METADATA
+    );
+
+    check(tournamentRes, {
+      '[TournamentFilter] Status is OK': (r) => r.status === grpc.StatusOK,
+      '[TournamentFilter] Response has matches': (r) =>
+        r.message != null && Array.isArray(r.message.matches),
+      '[TournamentFilter] All matches belong to filtered tournament': (r) => {
+        if (!r.message || !Array.isArray(r.message.matches)) return false;
+        return r.message.matches.every(m => m.tournament?.urn === sampleTournamentUrn);
+      },
+      '[TournamentFilter] Filtered count <= total count': (r) => {
+        if (!r.message || !Array.isArray(r.message.matches)) return false;
+        return r.message.matches.length <= allMatches.length;
+      },
+    });
+  }
+
+  // --- Test 3: Filter by match URN (should return exactly 1 match) ---
+  if (sampleMatchUrn) {
+    const matchRes = client.invoke(
+      'bragi.Bragi/MatchTimeline',
+      { live_only: false, match_urn: sampleMatchUrn },
+      METADATA
+    );
+
+    check(matchRes, {
+      '[MatchFilter] Status is OK': (r) => r.status === grpc.StatusOK,
+      '[MatchFilter] Returns exactly 1 match': (r) =>
+        r.message != null && Array.isArray(r.message.matches) && r.message.matches.length === 1,
+      '[MatchFilter] Returned match URN matches filter': (r) => {
+        if (!r.message || !Array.isArray(r.message.matches) || r.message.matches.length === 0) return false;
+        return r.message.matches[0].matchUrn === sampleMatchUrn;
+      },
+    });
+  }
+
+  // --- Test 4: Filter by team name ---
+  if (sampleTeamName) {
+    const teamRes = client.invoke(
+      'bragi.Bragi/MatchTimeline',
+      { live_only: false, team_name: sampleTeamName },
+      METADATA
+    );
+
+    check(teamRes, {
+      '[TeamNameFilter] Status is OK': (r) => r.status === grpc.StatusOK,
+      '[TeamNameFilter] Response has matches': (r) =>
+        r.message != null && Array.isArray(r.message.matches),
+      '[TeamNameFilter] All matches contain the filtered team': (r) => {
+        if (!r.message || !Array.isArray(r.message.matches)) return false;
+        return r.message.matches.every(m =>
+          Array.isArray(m.teams) && m.teams.some(t => t.name === sampleTeamName)
+        );
+      },
+    });
+  }
+
+  // --- Test 5: live_only=true ---
+  const liveRes = client.invoke('bragi.Bragi/MatchTimeline', { live_only: true }, METADATA);
+
+  check(liveRes, {
+    '[LiveOnly] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[LiveOnly] Response message is not null': (r) => r.message != null,
+    '[LiveOnly] Live matches count <= all matches count': (r) => {
+      if (!r.message || !Array.isArray(r.message.matches)) return true; // empty is valid
+      return r.message.matches.length <= allMatches.length;
+    },
+    '[LiveOnly] All matches are live': (r) => {
+      if (!r.message || !Array.isArray(r.message.matches)) return true;
+      return r.message.matches.every(m => m.matchStatus === 'MATCH_STATUS_TYPE_LIVE');
+    },
+  });
+
+  // --- Test 6: Combined filters (sport + live_only) ---
+  if (sampleSport) {
+    const combinedRes = client.invoke(
+      'bragi.Bragi/MatchTimeline',
+      { live_only: true, sport: sampleSport },
+      METADATA
+    );
+
+    check(combinedRes, {
+      '[CombinedFilter] Status is OK': (r) => r.status === grpc.StatusOK,
+      '[CombinedFilter] Response message is not null': (r) => r.message != null,
+    });
+  }
+
+  // --- Test 7: Nonexistent tournament URN returns empty ---
+  const emptyRes = client.invoke(
+    'bragi.Bragi/MatchTimeline',
+    { live_only: false, tournament_urn: 'od:tournament:999999999' },
+    METADATA
+  );
+
+  check(emptyRes, {
+    '[NonexistentTournament] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[NonexistentTournament] Returns empty matches array': (r) =>
+      r.message != null && Array.isArray(r.message.matches) && r.message.matches.length === 0,
+  });
+
+  client.close();
+}

--- a/k6/match_timeline_filters.js
+++ b/k6/match_timeline_filters.js
@@ -18,7 +18,7 @@ if (!BRAGI_TOKEN) {
 const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
-  client.connect(GRPC_ADDR);
+  client.connect(GRPC_ADDR, { plaintext: false });
 
   // --- Baseline: Get all matches to extract filter values ---
   const allRes = client.invoke('bragi.Bragi/MatchTimeline', { liveOnly: false }, METADATA);

--- a/k6/match_timeline_filters.js
+++ b/k6/match_timeline_filters.js
@@ -29,6 +29,13 @@ export default function () {
       r.message != null && Array.isArray(r.message.matches) && r.message.matches.length > 0,
   });
 
+  check(allRes.message, {
+    '[Baseline] Returned at least one match': (m) => m.matches && m.matches.length > 0,
+  });
+  if (!allRes.message?.matches || allRes.message.matches.length === 0) {
+    throw new Error('No matches returned from baseline MatchTimeline; cannot test filters');
+  }
+
   const allMatches = allRes.message?.matches || [];
   let sampleMatch = null;
   let sampleTournamentUrn = null;

--- a/k6/match_timeline_filters.js
+++ b/k6/match_timeline_filters.js
@@ -21,7 +21,7 @@ export default function () {
   client.connect(GRPC_ADDR);
 
   // --- Baseline: Get all matches to extract filter values ---
-  const allRes = client.invoke('bragi.Bragi/MatchTimeline', { live_only: false }, METADATA);
+  const allRes = client.invoke('bragi.Bragi/MatchTimeline', { liveOnly: false }, METADATA);
 
   check(allRes, {
     '[Baseline] Status is OK': (r) => r.status === grpc.StatusOK,
@@ -50,7 +50,7 @@ export default function () {
   if (sampleSport) {
     const sportRes = client.invoke(
       'bragi.Bragi/MatchTimeline',
-      { live_only: false, sport: sampleSport },
+      { liveOnly: false, sport: sampleSport },
       METADATA
     );
 
@@ -73,7 +73,7 @@ export default function () {
   if (sampleTournamentUrn) {
     const tournamentRes = client.invoke(
       'bragi.Bragi/MatchTimeline',
-      { live_only: false, tournament_urn: sampleTournamentUrn },
+      { liveOnly: false, tournamentUrn: sampleTournamentUrn },
       METADATA
     );
 
@@ -96,7 +96,7 @@ export default function () {
   if (sampleMatchUrn) {
     const matchRes = client.invoke(
       'bragi.Bragi/MatchTimeline',
-      { live_only: false, match_urn: sampleMatchUrn },
+      { liveOnly: false, matchUrn: sampleMatchUrn },
       METADATA
     );
 
@@ -115,7 +115,7 @@ export default function () {
   if (sampleTeamName) {
     const teamRes = client.invoke(
       'bragi.Bragi/MatchTimeline',
-      { live_only: false, team_name: sampleTeamName },
+      { liveOnly: false, teamName: sampleTeamName },
       METADATA
     );
 
@@ -133,7 +133,7 @@ export default function () {
   }
 
   // --- Test 5: live_only=true ---
-  const liveRes = client.invoke('bragi.Bragi/MatchTimeline', { live_only: true }, METADATA);
+  const liveRes = client.invoke('bragi.Bragi/MatchTimeline', { liveOnly: true }, METADATA);
 
   check(liveRes, {
     '[LiveOnly] Status is OK': (r) => r.status === grpc.StatusOK,
@@ -152,7 +152,7 @@ export default function () {
   if (sampleSport) {
     const combinedRes = client.invoke(
       'bragi.Bragi/MatchTimeline',
-      { live_only: true, sport: sampleSport },
+      { liveOnly: true, sport: sampleSport },
       METADATA
     );
 
@@ -165,7 +165,7 @@ export default function () {
   // --- Test 7: Nonexistent tournament URN returns empty ---
   const emptyRes = client.invoke(
     'bragi.Bragi/MatchTimeline',
-    { live_only: false, tournament_urn: 'od:tournament:999999999' },
+    { liveOnly: false, tournamentUrn: 'od:tournament:999999999' },
     METADATA
   );
 

--- a/k6/match_timeline_sports.js
+++ b/k6/match_timeline_sports.js
@@ -21,7 +21,7 @@ export default function () {
   client.connect(GRPC_ADDR);
 
   // --- Test 1: MatchTimelineSports with live_only=false (all matches) ---
-  const allSportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { live_only: false }, METADATA);
+  const allSportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { liveOnly: false }, METADATA);
 
   check(allSportsRes, {
     '[AllSports] Status is OK': (r) => r.status === grpc.StatusOK,
@@ -62,7 +62,7 @@ export default function () {
   }
 
   // --- Test 2: MatchTimelineSports with live_only=true (live matches only) ---
-  const liveSportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { live_only: true }, METADATA);
+  const liveSportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { liveOnly: true }, METADATA);
 
   check(liveSportsRes, {
     '[LiveSports] Status is OK': (r) => r.status === grpc.StatusOK,

--- a/k6/match_timeline_sports.js
+++ b/k6/match_timeline_sports.js
@@ -11,7 +11,11 @@ export const options = {
 };
 
 const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
   client.connect(GRPC_ADDR);

--- a/k6/match_timeline_sports.js
+++ b/k6/match_timeline_sports.js
@@ -18,7 +18,7 @@ if (!BRAGI_TOKEN) {
 const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
-  client.connect(GRPC_ADDR);
+  client.connect(GRPC_ADDR, { plaintext: false });
 
   // --- Test 1: MatchTimelineSports with live_only=false (all matches) ---
   const allSportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { liveOnly: false }, METADATA);

--- a/k6/match_timeline_sports.js
+++ b/k6/match_timeline_sports.js
@@ -1,0 +1,87 @@
+import grpc from 'k6/net/grpc';
+import { check } from 'k6';
+
+const client = new grpc.Client();
+client.load(['../proto'], 'bragi/bragi_service.proto');
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+
+export default function () {
+  client.connect(GRPC_ADDR);
+
+  // --- Test 1: MatchTimelineSports with live_only=false (all matches) ---
+  const allSportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { live_only: false }, METADATA);
+
+  check(allSportsRes, {
+    '[AllSports] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[AllSports] Response message is not null': (r) => r.message != null,
+  });
+
+  if (allSportsRes.message) {
+    const sports = allSportsRes.message.sports;
+
+    check(sports, {
+      '[AllSports] sports is an array': (s) => Array.isArray(s),
+      '[AllSports] At least one sport returned': (s) => Array.isArray(s) && s.length > 0,
+    });
+
+    if (Array.isArray(sports) && sports.length > 0) {
+      const firstSport = sports[0];
+
+      check(firstSport, {
+        '[AllSports] Each item has sport field': (s) => typeof s.sport === 'string' && s.sport.length > 0,
+        '[AllSports] Each item has matchCount field': (s) => typeof s.matchCount === 'number',
+        '[AllSports] matchCount is non-negative': (s) => s.matchCount >= 0,
+        '[AllSports] sport is a valid enum value': (s) => [
+          'SPORT_CS2', 'SPORT_DOTA2', 'SPORT_LOL', 'SPORT_VALORANT',
+          'SPORT_RUSH_SOCCER', 'SPORT_RUSH_BASKETBALL',
+        ].includes(s.sport),
+      });
+
+      // Validate all sports have valid structure
+      check(sports, {
+        '[AllSports] All items have sport and matchCount': (items) =>
+          items.every(s => typeof s.sport === 'string' && typeof s.matchCount === 'number'),
+        '[AllSports] No duplicate sports': (items) => {
+          const sportNames = items.map(s => s.sport);
+          return new Set(sportNames).size === sportNames.length;
+        },
+      });
+    }
+  }
+
+  // --- Test 2: MatchTimelineSports with live_only=true (live matches only) ---
+  const liveSportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { live_only: true }, METADATA);
+
+  check(liveSportsRes, {
+    '[LiveSports] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[LiveSports] Response message is not null': (r) => r.message != null,
+  });
+
+  if (liveSportsRes.message) {
+    const liveSports = liveSportsRes.message.sports;
+
+    check(liveSports, {
+      '[LiveSports] sports is an array': (s) => Array.isArray(s),
+    });
+
+    // Live sports count should be <= all sports count
+    if (allSportsRes.message && Array.isArray(liveSports) && Array.isArray(allSportsRes.message.sports)) {
+      const liveTotal = liveSports.reduce((sum, s) => sum + (s.matchCount || 0), 0);
+      const allTotal = allSportsRes.message.sports.reduce((sum, s) => sum + (s.matchCount || 0), 0);
+
+      check({ liveTotal, allTotal }, {
+        '[LiveSports] Live match count <= all match count': (v) => v.liveTotal <= v.allTotal,
+      });
+    }
+  }
+
+  client.close();
+}

--- a/k6/match_timeline_sports_feed.js
+++ b/k6/match_timeline_sports_feed.js
@@ -72,5 +72,9 @@ export default function () {
 
   sleep(10);
 
+  check(state, {
+    '[MatchTimelineSportsFeed] Received at least one message': (s) => s.messageReceived === true,
+  });
+
   client.close();
 }

--- a/k6/match_timeline_sports_feed.js
+++ b/k6/match_timeline_sports_feed.js
@@ -11,7 +11,11 @@ export const options = {
 };
 
 const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
   client.connect(GRPC_ADDR);

--- a/k6/match_timeline_sports_feed.js
+++ b/k6/match_timeline_sports_feed.js
@@ -1,0 +1,72 @@
+import { Client, Stream } from 'k6/net/grpc';
+import { check, sleep } from 'k6';
+
+const client = new Client();
+client.load(['../proto'], 'bragi/bragi_service.proto');
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+
+export default function () {
+  client.connect(GRPC_ADDR);
+
+  // --- Test 1: MatchTimelineSportsFeed with live_only=false ---
+  const stream = new Stream(client, 'bragi.Bragi/MatchTimelineSportsFeed', METADATA);
+
+  const state = { messageReceived: false };
+
+  stream.on('data', (msg) => {
+    check(msg, {
+      '[SportsFeed] Received a message': (m) => m != null,
+    });
+
+    if (msg && !state.messageReceived) {
+      state.messageReceived = true;
+
+      const sports = msg.sports;
+
+      check(msg, {
+        '[SportsFeed] Message has sports array': (m) => Array.isArray(m.sports),
+      });
+
+      if (Array.isArray(sports) && sports.length > 0) {
+        check(sports, {
+          '[SportsFeed] At least one sport in feed': (s) => s.length > 0,
+          '[SportsFeed] Each item has sport field': (s) =>
+            s.every(item => typeof item.sport === 'string' && item.sport.length > 0),
+          '[SportsFeed] Each item has matchCount': (s) =>
+            s.every(item => typeof item.matchCount === 'number'),
+          '[SportsFeed] All matchCounts are non-negative': (s) =>
+            s.every(item => item.matchCount >= 0),
+          '[SportsFeed] Sports are valid enum values': (s) =>
+            s.every(item => [
+              'SPORT_CS2', 'SPORT_DOTA2', 'SPORT_LOL', 'SPORT_VALORANT',
+              'SPORT_RUSH_SOCCER', 'SPORT_RUSH_BASKETBALL',
+            ].includes(item.sport)),
+          '[SportsFeed] No duplicate sports in message': (s) => {
+            const sportNames = s.map(item => item.sport);
+            return new Set(sportNames).size === sportNames.length;
+          },
+        });
+      }
+
+      stream.end();
+    }
+  });
+
+  stream.on('error', (err) => {
+    console.log('SportsFeed stream error:', err.message);
+  });
+
+  stream.write({ live_only: false });
+
+  sleep(10);
+
+  client.close();
+}

--- a/k6/match_timeline_sports_feed.js
+++ b/k6/match_timeline_sports_feed.js
@@ -68,7 +68,7 @@ export default function () {
     console.log('SportsFeed stream error:', err.message);
   });
 
-  stream.write({ live_only: false });
+  stream.write({ liveOnly: false });
 
   sleep(10);
 

--- a/k6/match_timeline_sports_feed.js
+++ b/k6/match_timeline_sports_feed.js
@@ -18,7 +18,7 @@ if (!BRAGI_TOKEN) {
 const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
-  client.connect(GRPC_ADDR);
+  client.connect(GRPC_ADDR, { plaintext: false });
 
   // --- Test 1: MatchTimelineSportsFeed with live_only=false ---
   const stream = new Stream(client, 'bragi.Bragi/MatchTimelineSportsFeed', METADATA);

--- a/k6/match_timeline_tournaments.js
+++ b/k6/match_timeline_tournaments.js
@@ -1,0 +1,123 @@
+import grpc from 'k6/net/grpc';
+import { check } from 'k6';
+
+const client = new grpc.Client();
+client.load(['../proto'], 'bragi/bragi_service.proto');
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+
+export default function () {
+  client.connect(GRPC_ADDR);
+
+  // --- Test 1: Get all sports first so we can query tournaments per sport ---
+  const sportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { live_only: false }, METADATA);
+
+  check(sportsRes, {
+    '[Sports] Status is OK': (r) => r.status === grpc.StatusOK,
+  });
+
+  // --- Test 2: MatchTimelineTournaments with CS2 sport (used as baseline) ---
+  const allTournamentsRes = client.invoke(
+    'bragi.Bragi/MatchTimelineTournaments',
+    { live_only: false, sport: 'SPORT_CS2' },
+    METADATA
+  );
+
+  check(allTournamentsRes, {
+    '[AllTournaments] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[AllTournaments] Response message is not null': (r) => r.message != null,
+  });
+
+  if (allTournamentsRes.message) {
+    const tournaments = allTournamentsRes.message.tournaments;
+
+    check(tournaments, {
+      '[AllTournaments] tournaments is an array': (t) => Array.isArray(t),
+      '[AllTournaments] At least one tournament returned': (t) => Array.isArray(t) && t.length > 0,
+    });
+
+    if (Array.isArray(tournaments) && tournaments.length > 0) {
+      const first = tournaments[0];
+
+      check(first, {
+        '[AllTournaments] Has tournament object': (t) => t.tournament != null,
+        '[AllTournaments] Has matchCount': (t) => typeof t.matchCount === 'number',
+        '[AllTournaments] matchCount is positive': (t) => t.matchCount > 0,
+      });
+
+      if (first.tournament) {
+        check(first.tournament, {
+          '[AllTournaments] Tournament has urn': (t) => typeof t.urn === 'string' && t.urn.length > 0,
+          '[AllTournaments] Tournament has name': (t) => typeof t.name === 'string' && t.name.length > 0,
+          '[AllTournaments] Tournament urn starts with od:tournament:': (t) => t.urn.startsWith('od:tournament:'),
+          '[AllTournaments] Tournament has isOffline boolean': (t) => typeof t.isOffline === 'boolean',
+        });
+      }
+
+      // Validate all tournaments have valid structure
+      check(tournaments, {
+        '[AllTournaments] All items have tournament and matchCount': (items) =>
+          items.every(t => t.tournament != null && typeof t.matchCount === 'number'),
+        '[AllTournaments] No duplicate tournament URNs': (items) => {
+          const urns = items.map(t => t.tournament?.urn);
+          return new Set(urns).size === urns.length;
+        },
+      });
+    }
+  }
+
+  // --- Test 3: MatchTimelineTournaments filtered by CS2 sport ---
+  const cs2TournamentsRes = client.invoke(
+    'bragi.Bragi/MatchTimelineTournaments',
+    { live_only: false, sport: 'SPORT_CS2' },
+    METADATA
+  );
+
+  check(cs2TournamentsRes, {
+    '[CS2Tournaments] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[CS2Tournaments] Response message is not null': (r) => r.message != null,
+  });
+
+  // --- Test 4: MatchTimelineTournaments filtered by Dota2 sport ---
+  const dota2TournamentsRes = client.invoke(
+    'bragi.Bragi/MatchTimelineTournaments',
+    { live_only: false, sport: 'SPORT_DOTA2' },
+    METADATA
+  );
+
+  check(dota2TournamentsRes, {
+    '[Dota2Tournaments] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[Dota2Tournaments] Response message is not null': (r) => r.message != null,
+  });
+
+  // --- Test 5: MatchTimelineTournaments with live_only=true ---
+  const liveTournamentsRes = client.invoke(
+    'bragi.Bragi/MatchTimelineTournaments',
+    { live_only: true, sport: 'SPORT_CS2' },
+    METADATA
+  );
+
+  check(liveTournamentsRes, {
+    '[LiveTournaments] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[LiveTournaments] Response message is not null': (r) => r.message != null,
+  });
+
+  // Live tournaments count should be <= all tournaments count
+  if (liveTournamentsRes.message && allTournamentsRes.message) {
+    const liveCount = (liveTournamentsRes.message.tournaments || []).length;
+    const allCount = (allTournamentsRes.message.tournaments || []).length;
+
+    check({ liveCount, allCount }, {
+      '[LiveTournaments] Live tournaments count <= all tournaments count': (v) => v.liveCount <= v.allCount,
+    });
+  }
+
+  client.close();
+}

--- a/k6/match_timeline_tournaments.js
+++ b/k6/match_timeline_tournaments.js
@@ -77,15 +77,7 @@ export default function () {
     }
   }
 
-  // --- Test 3: Reuse CS2 response from Test 2 (same params) ---
-  const cs2TournamentsRes = allTournamentsRes;
-
-  check(cs2TournamentsRes, {
-    '[CS2Tournaments] Status is OK': (r) => r.status === grpc.StatusOK,
-    '[CS2Tournaments] Response message is not null': (r) => r.message != null,
-  });
-
-  // --- Test 4: MatchTimelineTournaments filtered by Dota2 sport ---
+  // --- Test 3: MatchTimelineTournaments filtered by Dota2 sport ---
   const dota2TournamentsRes = client.invoke(
     'bragi.Bragi/MatchTimelineTournaments',
     { liveOnly: false, sport: 'SPORT_DOTA2' },
@@ -97,7 +89,7 @@ export default function () {
     '[Dota2Tournaments] Response message is not null': (r) => r.message != null,
   });
 
-  // --- Test 5: MatchTimelineTournaments with live_only=true ---
+  // --- Test 4: MatchTimelineTournaments with live_only=true ---
   const liveTournamentsRes = client.invoke(
     'bragi.Bragi/MatchTimelineTournaments',
     { liveOnly: true, sport: 'SPORT_CS2' },

--- a/k6/match_timeline_tournaments.js
+++ b/k6/match_timeline_tournaments.js
@@ -70,7 +70,7 @@ export default function () {
     }
   }
 
-  // --- Test 3: MatchTimelineTournaments filtered by Dota2 sport ---
+  // --- Test 2: MatchTimelineTournaments filtered by Dota2 sport ---
   const dota2TournamentsRes = client.invoke(
     'bragi.Bragi/MatchTimelineTournaments',
     { liveOnly: false, sport: 'SPORT_DOTA2' },
@@ -82,7 +82,7 @@ export default function () {
     '[Dota2Tournaments] Response message is not null': (r) => r.message != null,
   });
 
-  // --- Test 4: MatchTimelineTournaments with live_only=true ---
+  // --- Test 3: MatchTimelineTournaments with live_only=true ---
   const liveTournamentsRes = client.invoke(
     'bragi.Bragi/MatchTimelineTournaments',
     { liveOnly: true, sport: 'SPORT_CS2' },

--- a/k6/match_timeline_tournaments.js
+++ b/k6/match_timeline_tournaments.js
@@ -20,14 +20,7 @@ const METADATA = { metadata: { token: BRAGI_TOKEN } };
 export default function () {
   client.connect(GRPC_ADDR, { plaintext: false });
 
-  // --- Test 1: Get all sports first so we can query tournaments per sport ---
-  const sportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { liveOnly: false }, METADATA);
-
-  check(sportsRes, {
-    '[Sports] Status is OK': (r) => r.status === grpc.StatusOK,
-  });
-
-  // --- Test 2: MatchTimelineTournaments with CS2 sport (used as baseline) ---
+  // --- Test 1: MatchTimelineTournaments with CS2 sport (used as baseline) ---
   const allTournamentsRes = client.invoke(
     'bragi.Bragi/MatchTimelineTournaments',
     { liveOnly: false, sport: 'SPORT_CS2' },

--- a/k6/match_timeline_tournaments.js
+++ b/k6/match_timeline_tournaments.js
@@ -11,7 +11,11 @@ export const options = {
 };
 
 const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
   client.connect(GRPC_ADDR);
@@ -73,12 +77,8 @@ export default function () {
     }
   }
 
-  // --- Test 3: MatchTimelineTournaments filtered by CS2 sport ---
-  const cs2TournamentsRes = client.invoke(
-    'bragi.Bragi/MatchTimelineTournaments',
-    { live_only: false, sport: 'SPORT_CS2' },
-    METADATA
-  );
+  // --- Test 3: Reuse CS2 response from Test 2 (same params) ---
+  const cs2TournamentsRes = allTournamentsRes;
 
   check(cs2TournamentsRes, {
     '[CS2Tournaments] Status is OK': (r) => r.status === grpc.StatusOK,

--- a/k6/match_timeline_tournaments.js
+++ b/k6/match_timeline_tournaments.js
@@ -18,7 +18,7 @@ if (!BRAGI_TOKEN) {
 const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
-  client.connect(GRPC_ADDR);
+  client.connect(GRPC_ADDR, { plaintext: false });
 
   // --- Test 1: Get all sports first so we can query tournaments per sport ---
   const sportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { liveOnly: false }, METADATA);

--- a/k6/match_timeline_tournaments.js
+++ b/k6/match_timeline_tournaments.js
@@ -21,7 +21,7 @@ export default function () {
   client.connect(GRPC_ADDR);
 
   // --- Test 1: Get all sports first so we can query tournaments per sport ---
-  const sportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { live_only: false }, METADATA);
+  const sportsRes = client.invoke('bragi.Bragi/MatchTimelineSports', { liveOnly: false }, METADATA);
 
   check(sportsRes, {
     '[Sports] Status is OK': (r) => r.status === grpc.StatusOK,
@@ -30,7 +30,7 @@ export default function () {
   // --- Test 2: MatchTimelineTournaments with CS2 sport (used as baseline) ---
   const allTournamentsRes = client.invoke(
     'bragi.Bragi/MatchTimelineTournaments',
-    { live_only: false, sport: 'SPORT_CS2' },
+    { liveOnly: false, sport: 'SPORT_CS2' },
     METADATA
   );
 
@@ -88,7 +88,7 @@ export default function () {
   // --- Test 4: MatchTimelineTournaments filtered by Dota2 sport ---
   const dota2TournamentsRes = client.invoke(
     'bragi.Bragi/MatchTimelineTournaments',
-    { live_only: false, sport: 'SPORT_DOTA2' },
+    { liveOnly: false, sport: 'SPORT_DOTA2' },
     METADATA
   );
 
@@ -100,7 +100,7 @@ export default function () {
   // --- Test 5: MatchTimelineTournaments with live_only=true ---
   const liveTournamentsRes = client.invoke(
     'bragi.Bragi/MatchTimelineTournaments',
-    { live_only: true, sport: 'SPORT_CS2' },
+    { liveOnly: true, sport: 'SPORT_CS2' },
     METADATA
   );
 

--- a/k6/match_timeline_tournaments_feed.js
+++ b/k6/match_timeline_tournaments_feed.js
@@ -1,0 +1,86 @@
+import { Client, Stream } from 'k6/net/grpc';
+import { check, sleep } from 'k6';
+
+const client = new Client();
+client.load(['../proto'], 'bragi/bragi_service.proto');
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+
+export default function () {
+  client.connect(GRPC_ADDR);
+
+  // --- Test 1: MatchTimelineTournamentsFeed (all sports) ---
+  const stream = new Stream(client, 'bragi.Bragi/MatchTimelineTournamentsFeed', METADATA);
+
+  const state = { messageReceived: false };
+
+  stream.on('data', (msg) => {
+    check(msg, {
+      '[TournamentsFeed] Received a message': (m) => m != null,
+    });
+
+    if (msg && !state.messageReceived) {
+      state.messageReceived = true;
+
+      const tournaments = msg.tournaments;
+
+      check(msg, {
+        '[TournamentsFeed] Message has tournaments array': (m) => Array.isArray(m.tournaments),
+      });
+
+      if (Array.isArray(tournaments) && tournaments.length > 0) {
+        check(tournaments, {
+          '[TournamentsFeed] At least one tournament in feed': (t) => t.length > 0,
+          '[TournamentsFeed] Each item has tournament object': (t) =>
+            t.every(item => item.tournament != null),
+          '[TournamentsFeed] Each item has matchCount': (t) =>
+            t.every(item => typeof item.matchCount === 'number'),
+          '[TournamentsFeed] All matchCounts are positive': (t) =>
+            t.every(item => item.matchCount > 0),
+        });
+
+        const firstTournament = tournaments[0].tournament;
+
+        if (firstTournament) {
+          check(firstTournament, {
+            '[TournamentsFeed] Tournament has urn': (t) =>
+              typeof t.urn === 'string' && t.urn.length > 0,
+            '[TournamentsFeed] Tournament has name': (t) =>
+              typeof t.name === 'string' && t.name.length > 0,
+            '[TournamentsFeed] Tournament urn starts with od:tournament:': (t) =>
+              t.urn.startsWith('od:tournament:'),
+            '[TournamentsFeed] Tournament has isOffline boolean': (t) =>
+              typeof t.isOffline === 'boolean',
+          });
+        }
+
+        // No duplicate tournament URNs
+        check(tournaments, {
+          '[TournamentsFeed] No duplicate tournament URNs': (items) => {
+            const urns = items.map(t => t.tournament?.urn);
+            return new Set(urns).size === urns.length;
+          },
+        });
+      }
+
+      stream.end();
+    }
+  });
+
+  stream.on('error', (err) => {
+    console.log('TournamentsFeed stream error:', err.message);
+  });
+
+  stream.write({ live_only: false, sport: 'SPORT_CS2' });
+
+  sleep(10);
+
+  client.close();
+}

--- a/k6/match_timeline_tournaments_feed.js
+++ b/k6/match_timeline_tournaments_feed.js
@@ -11,12 +11,16 @@ export const options = {
 };
 
 const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
   client.connect(GRPC_ADDR);
 
-  // --- Test 1: MatchTimelineTournamentsFeed (all sports) ---
+  // --- Test 1: MatchTimelineTournamentsFeed (CS2) ---
   const stream = new Stream(client, 'bragi.Bragi/MatchTimelineTournamentsFeed', METADATA);
 
   const state = { messageReceived: false };

--- a/k6/match_timeline_tournaments_feed.js
+++ b/k6/match_timeline_tournaments_feed.js
@@ -18,7 +18,7 @@ if (!BRAGI_TOKEN) {
 const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
-  client.connect(GRPC_ADDR);
+  client.connect(GRPC_ADDR, { plaintext: false });
 
   // --- Test 1: MatchTimelineTournamentsFeed (CS2) ---
   const stream = new Stream(client, 'bragi.Bragi/MatchTimelineTournamentsFeed', METADATA);

--- a/k6/match_timeline_tournaments_feed.js
+++ b/k6/match_timeline_tournaments_feed.js
@@ -86,5 +86,9 @@ export default function () {
 
   sleep(10);
 
+  check(state, {
+    '[MatchTimelineTournamentsFeed] Received at least one message': (s) => s.messageReceived === true,
+  });
+
   client.close();
 }

--- a/k6/match_timeline_tournaments_feed.js
+++ b/k6/match_timeline_tournaments_feed.js
@@ -82,7 +82,7 @@ export default function () {
     console.log('TournamentsFeed stream error:', err.message);
   });
 
-  stream.write({ live_only: false, sport: 'SPORT_CS2' });
+  stream.write({ liveOnly: false, sport: 'SPORT_CS2' });
 
   sleep(10);
 

--- a/k6/run_tests.ps1
+++ b/k6/run_tests.ps1
@@ -1,0 +1,86 @@
+$ErrorActionPreference = "Continue"
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$tests = @(
+    "match_timeline_sports.js",
+    "match_timeline_tournaments.js",
+    "team_profile.js",
+    "match_timeline_filters.js",
+    "match_timeline_sports_feed.js",
+    "match_timeline_tournaments_feed.js",
+    "match_timeline_feed.js",
+    "live_data_feed.js",
+    "match_events_feed.js"
+)
+
+Set-Location $PSScriptRoot
+
+Write-Host ""
+Write-Host "  ==========================================" -ForegroundColor Cyan
+Write-Host "    Bragi gRPC - K6 Test Suite" -ForegroundColor Cyan
+Write-Host "  ==========================================" -ForegroundColor Cyan
+Write-Host ""
+
+$results = @()
+$allFailures = @()
+$total = $tests.Count
+$idx = 0
+
+foreach ($test in $tests) {
+    $idx++
+    Write-Host "  [$idx/$total] Running $test ..." -ForegroundColor Gray
+
+    $output = & k6 run $test 2>&1 | Out-String
+    $exitCode = $LASTEXITCODE
+
+    $passed = ([regex]::Matches($output, [char]0x2713)).Count
+    $failed = ([regex]::Matches($output, [char]0x2717)).Count
+    $checkTotal = $passed + $failed
+
+    $failedLines = $output -split "`n" | Where-Object { $_ -match [char]0x2717 -and $_ -notmatch "rate=" }
+
+    $result = [PSCustomObject]@{
+        File = $test
+        Passed = $passed
+        Total = $checkTotal
+        Status = if ($exitCode -eq 0) { "PASS" } else { "FAIL" }
+    }
+    $results += $result
+
+    foreach ($line in $failedLines) {
+        $trimmed = $line.Trim()
+        if ($trimmed) {
+            $allFailures += "    $test : $trimmed"
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "  ==========================================" -ForegroundColor Cyan
+Write-Host "    BRAGI TEST RESULTS" -ForegroundColor Cyan
+Write-Host "  ==========================================" -ForegroundColor Cyan
+Write-Host ""
+
+foreach ($r in $results) {
+    $color = if ($r.Status -eq "PASS") { "Green" } else { "Red" }
+    $icon = if ($r.Status -eq "PASS") { "PASS" } else { "FAIL" }
+    Write-Host ("  {0}  {1,-45} [{2}/{3}]" -f $icon, $r.File, $r.Passed, $r.Total) -ForegroundColor $color
+}
+
+$passCount = ($results | Where-Object { $_.Status -eq "PASS" }).Count
+$failCount = ($results | Where-Object { $_.Status -eq "FAIL" }).Count
+
+Write-Host ""
+Write-Host "  ------------------------------------------" -ForegroundColor Cyan
+Write-Host "   $passCount passed, $failCount failed out of $total" -ForegroundColor $(if ($failCount -eq 0) { "Green" } else { "Red" })
+Write-Host "  ------------------------------------------" -ForegroundColor Cyan
+
+if ($allFailures.Count -gt 0) {
+    Write-Host ""
+    Write-Host "  FAILED CHECKS:" -ForegroundColor Red
+    Write-Host ""
+    foreach ($f in $allFailures) {
+        Write-Host $f -ForegroundColor Red
+    }
+    Write-Host ""
+}

--- a/k6/run_tests.ps1
+++ b/k6/run_tests.ps1
@@ -84,3 +84,7 @@ if ($allFailures.Count -gt 0) {
     }
     Write-Host ""
 }
+
+if ($failCount -gt 0) {
+    exit 1
+}

--- a/k6/run_tests.ps1
+++ b/k6/run_tests.ps1
@@ -1,5 +1,10 @@
-$ErrorActionPreference = "Continue"
+$ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+if (-not (Get-Command k6 -ErrorAction SilentlyContinue)) {
+    Write-Host "ERROR: k6 is not installed or not in PATH" -ForegroundColor Red
+    exit 1
+}
 
 $tests = @(
     "match_timeline_sports.js",

--- a/k6/team_profile.js
+++ b/k6/team_profile.js
@@ -21,7 +21,7 @@ export default function () {
   client.connect(GRPC_ADDR);
 
   // --- Step 1: Get a real team URN from MatchTimeline ---
-  const timelineRes = client.invoke('bragi.Bragi/MatchTimeline', { live_only: false }, METADATA);
+  const timelineRes = client.invoke('bragi.Bragi/MatchTimeline', { liveOnly: false }, METADATA);
 
   check(timelineRes, {
     '[Setup] MatchTimeline status is OK': (r) => r.status === grpc.StatusOK,
@@ -45,7 +45,7 @@ export default function () {
 
   // --- Test 1: TeamProfile with valid team URN ---
   if (teamUrn) {
-    const profileRes = client.invoke('bragi.Bragi/TeamProfile', { team_urn: teamUrn }, METADATA);
+    const profileRes = client.invoke('bragi.Bragi/TeamProfile', { teamUrn: teamUrn }, METADATA);
 
     check(profileRes, {
       '[TeamProfile] Status is OK': (r) => r.status === grpc.StatusOK,
@@ -109,14 +109,14 @@ export default function () {
   }
 
   // --- Test 2: TeamProfile with invalid/nonexistent URN ---
-  const invalidRes = client.invoke('bragi.Bragi/TeamProfile', { team_urn: 'od:competitor:999999999' }, METADATA);
+  const invalidRes = client.invoke('bragi.Bragi/TeamProfile', { teamUrn: 'od:competitor:999999999' }, METADATA);
 
   check(invalidRes, {
     '[InvalidTeam] Request completes without crash': (r) => r.status !== undefined,
   });
 
   // --- Test 3: TeamProfile with empty URN ---
-  const emptyRes = client.invoke('bragi.Bragi/TeamProfile', { team_urn: '' }, METADATA);
+  const emptyRes = client.invoke('bragi.Bragi/TeamProfile', { teamUrn: '' }, METADATA);
 
   check(emptyRes, {
     '[EmptyTeam] Request completes without crash': (r) => r.status !== undefined,

--- a/k6/team_profile.js
+++ b/k6/team_profile.js
@@ -11,7 +11,11 @@ export const options = {
 };
 
 const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
-const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+const BRAGI_TOKEN = __ENV.BRAGI_TOKEN;
+if (!BRAGI_TOKEN) {
+  throw new Error('Missing required environment variable: BRAGI_TOKEN');
+}
+const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
   client.connect(GRPC_ADDR);

--- a/k6/team_profile.js
+++ b/k6/team_profile.js
@@ -18,7 +18,7 @@ if (!BRAGI_TOKEN) {
 const METADATA = { metadata: { token: BRAGI_TOKEN } };
 
 export default function () {
-  client.connect(GRPC_ADDR);
+  client.connect(GRPC_ADDR, { plaintext: false });
 
   // --- Step 1: Get a real team URN from MatchTimeline ---
   const timelineRes = client.invoke('bragi.Bragi/MatchTimeline', { liveOnly: false }, METADATA);

--- a/k6/team_profile.js
+++ b/k6/team_profile.js
@@ -1,0 +1,115 @@
+import grpc from 'k6/net/grpc';
+import { check } from 'k6';
+
+const client = new grpc.Client();
+client.load(['../proto'], 'bragi/bragi_service.proto');
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const GRPC_ADDR = __ENV.BRAGI_ADDR || 'api-bragi-test.integration.oddin.dev:443';
+const METADATA = { metadata: { token: __ENV.BRAGI_TOKEN || 'a9122914-31ee-4975-80f4-cb458d71d756' } };
+
+export default function () {
+  client.connect(GRPC_ADDR);
+
+  // --- Step 1: Get a real team URN from MatchTimeline ---
+  const timelineRes = client.invoke('bragi.Bragi/MatchTimeline', { live_only: false }, METADATA);
+
+  check(timelineRes, {
+    '[Setup] MatchTimeline status is OK': (r) => r.status === grpc.StatusOK,
+  });
+
+  let teamUrn = null;
+
+  if (timelineRes.message && Array.isArray(timelineRes.message.matches) && timelineRes.message.matches.length > 0) {
+    const match = timelineRes.message.matches[0];
+    if (Array.isArray(match.teams) && match.teams.length > 0) {
+      teamUrn = match.teams[0].urn;
+    }
+  }
+
+  // --- Test 1: TeamProfile with valid team URN ---
+  if (teamUrn) {
+    const profileRes = client.invoke('bragi.Bragi/TeamProfile', { team_urn: teamUrn }, METADATA);
+
+    check(profileRes, {
+      '[TeamProfile] Status is OK': (r) => r.status === grpc.StatusOK,
+      '[TeamProfile] Response message is not null': (r) => r.message != null,
+    });
+
+    if (profileRes.message && profileRes.message.team) {
+      const team = profileRes.message.team;
+
+      check(team, {
+        '[TeamProfile] Has urn': (t) => typeof t.urn === 'string' && t.urn.length > 0,
+        '[TeamProfile] Has name': (t) => typeof t.name === 'string' && t.name.length > 0,
+        '[TeamProfile] URN matches requested URN': (t) => t.urn === teamUrn,
+        '[TeamProfile] URN starts with od:competitor: or od:team:': (t) =>
+          t.urn.startsWith('od:competitor:') || t.urn.startsWith('od:team:'),
+      });
+
+      // Validate players array if present
+      if (Array.isArray(team.players) && team.players.length > 0) {
+        check(team.players, {
+          '[TeamProfile] players is an array': (p) => Array.isArray(p),
+        });
+
+        const firstPlayer = team.players[0];
+
+        check(firstPlayer, {
+          '[TeamProfile] Player has urn': (p) => typeof p.urn === 'string' && p.urn.length > 0,
+          '[TeamProfile] Player has nickname': (p) => typeof p.nickname === 'string' && p.nickname.length > 0,
+          '[TeamProfile] Player urn starts with od:player:': (p) => p.urn.startsWith('od:player:'),
+        });
+
+        // Validate all players have required fields
+        check(team.players, {
+          '[TeamProfile] All players have urn and nickname': (players) =>
+            players.every(p => typeof p.urn === 'string' && typeof p.nickname === 'string'),
+          '[TeamProfile] No duplicate player URNs': (players) => {
+            const urns = players.map(p => p.urn);
+            return new Set(urns).size === urns.length;
+          },
+        });
+      }
+
+      // Validate currentMapRoster if present
+      if (Array.isArray(team.currentMapRoster) && team.currentMapRoster.length > 0) {
+        check(team.currentMapRoster, {
+          '[TeamProfile] currentMapRoster is an array': (r) => Array.isArray(r),
+          '[TeamProfile] Roster players have urn': (r) =>
+            r.every(p => typeof p.urn === 'string' && p.urn.length > 0),
+          '[TeamProfile] Roster players have nickname': (r) =>
+            r.every(p => typeof p.nickname === 'string' && p.nickname.length > 0),
+        });
+      }
+
+      // Validate externalIdentities map if present
+      if (team.externalIdentities) {
+        check(team.externalIdentities, {
+          '[TeamProfile] externalIdentities is an object': (ei) => typeof ei === 'object',
+        });
+      }
+    }
+  }
+
+  // --- Test 2: TeamProfile with invalid/nonexistent URN ---
+  const invalidRes = client.invoke('bragi.Bragi/TeamProfile', { team_urn: 'od:competitor:999999999' }, METADATA);
+
+  check(invalidRes, {
+    '[InvalidTeam] Request completes without crash': (r) => r.status !== undefined,
+  });
+
+  // --- Test 3: TeamProfile with empty URN ---
+  const emptyRes = client.invoke('bragi.Bragi/TeamProfile', { team_urn: '' }, METADATA);
+
+  check(emptyRes, {
+    '[EmptyTeam] Request completes without crash': (r) => r.status !== undefined,
+  });
+
+  client.close();
+}

--- a/k6/team_profile.js
+++ b/k6/team_profile.js
@@ -36,6 +36,13 @@ export default function () {
     }
   }
 
+  check(teamUrn, {
+    '[Setup] Team URN resolved from Bragi': (u) => u !== undefined && u !== null && u !== '',
+  });
+  if (!teamUrn) {
+    throw new Error('No team URN available from Bragi; failing instead of skipping TeamProfile tests');
+  }
+
   // --- Test 1: TeamProfile with valid team URN ---
   if (teamUrn) {
     const profileRes = client.invoke('bragi.Bragi/TeamProfile', { team_urn: teamUrn }, METADATA);

--- a/k6/team_profile.js
+++ b/k6/team_profile.js
@@ -44,67 +44,65 @@ export default function () {
   }
 
   // --- Test 1: TeamProfile with valid team URN ---
-  if (teamUrn) {
-    const profileRes = client.invoke('bragi.Bragi/TeamProfile', { teamUrn: teamUrn }, METADATA);
+  const profileRes = client.invoke('bragi.Bragi/TeamProfile', { teamUrn: teamUrn }, METADATA);
 
-    check(profileRes, {
-      '[TeamProfile] Status is OK': (r) => r.status === grpc.StatusOK,
-      '[TeamProfile] Response message is not null': (r) => r.message != null,
+  check(profileRes, {
+    '[TeamProfile] Status is OK': (r) => r.status === grpc.StatusOK,
+    '[TeamProfile] Response message is not null': (r) => r.message != null,
+  });
+
+  if (profileRes.message && profileRes.message.team) {
+    const team = profileRes.message.team;
+
+    check(team, {
+      '[TeamProfile] Has urn': (t) => typeof t.urn === 'string' && t.urn.length > 0,
+      '[TeamProfile] Has name': (t) => typeof t.name === 'string' && t.name.length > 0,
+      '[TeamProfile] URN matches requested URN': (t) => t.urn === teamUrn,
+      '[TeamProfile] URN starts with od:competitor: or od:team:': (t) =>
+        t.urn.startsWith('od:competitor:') || t.urn.startsWith('od:team:'),
     });
 
-    if (profileRes.message && profileRes.message.team) {
-      const team = profileRes.message.team;
-
-      check(team, {
-        '[TeamProfile] Has urn': (t) => typeof t.urn === 'string' && t.urn.length > 0,
-        '[TeamProfile] Has name': (t) => typeof t.name === 'string' && t.name.length > 0,
-        '[TeamProfile] URN matches requested URN': (t) => t.urn === teamUrn,
-        '[TeamProfile] URN starts with od:competitor: or od:team:': (t) =>
-          t.urn.startsWith('od:competitor:') || t.urn.startsWith('od:team:'),
+    // Validate players array if present
+    if (Array.isArray(team.players) && team.players.length > 0) {
+      check(team.players, {
+        '[TeamProfile] players is an array': (p) => Array.isArray(p),
       });
 
-      // Validate players array if present
-      if (Array.isArray(team.players) && team.players.length > 0) {
-        check(team.players, {
-          '[TeamProfile] players is an array': (p) => Array.isArray(p),
-        });
+      const firstPlayer = team.players[0];
 
-        const firstPlayer = team.players[0];
+      check(firstPlayer, {
+        '[TeamProfile] Player has urn': (p) => typeof p.urn === 'string' && p.urn.length > 0,
+        '[TeamProfile] Player has nickname': (p) => typeof p.nickname === 'string' && p.nickname.length > 0,
+        '[TeamProfile] Player urn starts with od:player:': (p) => p.urn.startsWith('od:player:'),
+      });
 
-        check(firstPlayer, {
-          '[TeamProfile] Player has urn': (p) => typeof p.urn === 'string' && p.urn.length > 0,
-          '[TeamProfile] Player has nickname': (p) => typeof p.nickname === 'string' && p.nickname.length > 0,
-          '[TeamProfile] Player urn starts with od:player:': (p) => p.urn.startsWith('od:player:'),
-        });
+      // Validate all players have required fields
+      check(team.players, {
+        '[TeamProfile] All players have urn and nickname': (players) =>
+          players.every(p => typeof p.urn === 'string' && typeof p.nickname === 'string'),
+        '[TeamProfile] No duplicate player URNs': (players) => {
+          const urns = players.map(p => p.urn);
+          return new Set(urns).size === urns.length;
+        },
+      });
+    }
 
-        // Validate all players have required fields
-        check(team.players, {
-          '[TeamProfile] All players have urn and nickname': (players) =>
-            players.every(p => typeof p.urn === 'string' && typeof p.nickname === 'string'),
-          '[TeamProfile] No duplicate player URNs': (players) => {
-            const urns = players.map(p => p.urn);
-            return new Set(urns).size === urns.length;
-          },
-        });
-      }
+    // Validate currentMapRoster if present
+    if (Array.isArray(team.currentMapRoster) && team.currentMapRoster.length > 0) {
+      check(team.currentMapRoster, {
+        '[TeamProfile] currentMapRoster is an array': (r) => Array.isArray(r),
+        '[TeamProfile] Roster players have urn': (r) =>
+          r.every(p => typeof p.urn === 'string' && p.urn.length > 0),
+        '[TeamProfile] Roster players have nickname': (r) =>
+          r.every(p => typeof p.nickname === 'string' && p.nickname.length > 0),
+      });
+    }
 
-      // Validate currentMapRoster if present
-      if (Array.isArray(team.currentMapRoster) && team.currentMapRoster.length > 0) {
-        check(team.currentMapRoster, {
-          '[TeamProfile] currentMapRoster is an array': (r) => Array.isArray(r),
-          '[TeamProfile] Roster players have urn': (r) =>
-            r.every(p => typeof p.urn === 'string' && p.urn.length > 0),
-          '[TeamProfile] Roster players have nickname': (r) =>
-            r.every(p => typeof p.nickname === 'string' && p.nickname.length > 0),
-        });
-      }
-
-      // Validate externalIdentities map if present
-      if (team.externalIdentities) {
-        check(team.externalIdentities, {
-          '[TeamProfile] externalIdentities is an object': (ei) => typeof ei === 'object',
-        });
-      }
+    // Validate externalIdentities map if present
+    if (team.externalIdentities) {
+      check(team.externalIdentities, {
+        '[TeamProfile] externalIdentities is an object': (ei) => typeof ei === 'object',
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Add 9 k6 gRPC test files for Bragi schema endpoints (match timeline, team profile, feeds)
- All tests use environment variables for configurable gRPC host and match IDs
- Add GitHub Actions workflow (`k6-tests.yml`) with manual dispatch and scheduled triggers, per-test toggles
- Add k6 testing README and update repo README with testing section

## Test plan
- [x] All 9 k6 tests pass locally at 100%
- [ ] Verify GitHub Actions workflow activates once CI is enabled for the repo
- [ ] Test `workflow_dispatch` manual trigger from Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)