### PR TITLE
Fix k6 streaming test assertions and Timestamp parsing

### DIFF
--- a/k6/live_data_feed.js
+++ b/k6/live_data_feed.js
@@ -117,15 +117,17 @@ export default function () {
     console.log('LiveDataFeed stream error:', err.message);
   });
 
+  stream.on('end', () => {
+    check(state, {
+      '[LiveDataFeed] Received at least one message': (s) => s.messageCount > 0,
+      '[LiveDataFeed] Received at least one match payload': (s) => s.matchReceived === true,
+    });
+  });
+
   // Send request without "after" - gets current live matches
   stream.write({});
 
   sleep(15);
-
-  check(state, {
-    '[LiveDataFeed] Received at least one message': (s) => s.messageCount > 0,
-    '[LiveDataFeed] Received at least one match payload': (s) => s.matchReceived === true,
-  });
 
   client.close();
 }

--- a/k6/match_events_feed.js
+++ b/k6/match_events_feed.js
@@ -109,12 +109,12 @@ export default function () {
           });
         }
 
-        // Validate timestamp ordering (events should be chronologically ordered)
+        // Validate timestamp ordering (timestamps are ISO 8601 strings)
         if (events.length >= 2) {
           const timestamps = events
             .map(e => e.timestamp)
-            .filter(t => t != null && t.seconds != null)
-            .map(t => Number(t.seconds));
+            .filter(t => typeof t === 'string' && t.length > 0)
+            .map(t => Date.parse(t));
 
           check(timestamps, {
             '[MatchEventsFeed] Events have timestamps': (ts) => ts.length > 0 && ts.every(t => Number.isFinite(t)),
@@ -139,6 +139,13 @@ export default function () {
     console.log('MatchEventsFeed stream error:', err.message);
   });
 
+  stream.on('end', () => {
+    check(state, {
+      '[MatchEventsFeed] Stream produced at least one message': (s) => s.messageCount > 0,
+      '[MatchEventsFeed] Received CS2 events': (s) => s.cs2EventsReceived === true,
+    });
+  });
+
   // MatchEventsFeedRequest has no parameters
   stream.write({});
 
@@ -148,11 +155,6 @@ export default function () {
     state.ended = true;
     stream.end();
   }
-
-  check(state, {
-    '[MatchEventsFeed] Stream produced at least one message': (s) => s.messageCount > 0,
-    '[MatchEventsFeed] Received CS2 events': (s) => s.cs2EventsReceived === true,
-  });
 
   client.close();
 }

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -43,17 +43,16 @@ export default function () {
       if (msg.timeline?.matches) {
         const matches = msg.timeline.matches;
 
-        // Each match has plannetStart (protobuf Timestamp: {seconds, nanos})
+        // plannetStart is a protobuf Timestamp serialized as ISO 8601 string
         check(matches, {
           '[MatchTimelineFeed] Each match has plannetStart': (ms) =>
-            ms.every(m => m.plannetStart != null && typeof m.plannetStart.seconds === 'string'),
+            ms.every(m => typeof m.plannetStart === 'string' && m.plannetStart.length > 0),
         });
 
-        // Timestamps do not move backwards
         const timestamps = matches
           .map(m => m.plannetStart)
-          .filter(t => t != null && t.seconds != null)
-          .map(t => Number(t.seconds));
+          .filter(t => typeof t === 'string' && t.length > 0)
+          .map(t => Date.parse(t));
 
         check(timestamps, {
           '[MatchTimelineFeed] Timestamps do not move backwards': (ts) => {
@@ -79,16 +78,18 @@ export default function () {
     console.log('Stream error:', err.message);
   });
 
+  stream.on('end', () => {
+    check(state, {
+      '[MatchTimelineFeed] Received at least one message': (s) => s.messageReceived === true,
+      '[MatchTimelineFeed] Received a timeline snapshot': (s) => s.timelineReceived === true,
+    });
+  });
+
   // Send request
   stream.write({ liveOnly: false });
 
   // Wait for data handler to fire and close stream
   sleep(10);
-
-  check(state, {
-    '[MatchTimelineFeed] Received at least one message': (s) => s.messageReceived === true,
-    '[MatchTimelineFeed] Received a timeline snapshot': (s) => s.timelineReceived === true,
-  });
 
   client.close();
 }

--- a/k6/match_timeline_feed.js
+++ b/k6/match_timeline_feed.js
@@ -55,7 +55,10 @@ export default function () {
           .map(t => Date.parse(t));
 
         check(timestamps, {
+          '[MatchTimelineFeed] All timestamps are valid': (ts) =>
+            ts.every(t => Number.isFinite(t)),
           '[MatchTimelineFeed] Timestamps do not move backwards': (ts) => {
+            if (!ts.every(t => Number.isFinite(t))) return false;
             for (let i = 1; i < ts.length; i++) {
               if (ts[i] < ts[i - 1]) return false;
             }

--- a/k6/match_timeline_sports_feed.js
+++ b/k6/match_timeline_sports_feed.js
@@ -68,13 +68,15 @@ export default function () {
     console.log('SportsFeed stream error:', err.message);
   });
 
+  stream.on('end', () => {
+    check(state, {
+      '[MatchTimelineSportsFeed] Received at least one message': (s) => s.messageReceived === true,
+    });
+  });
+
   stream.write({ liveOnly: false });
 
   sleep(10);
-
-  check(state, {
-    '[MatchTimelineSportsFeed] Received at least one message': (s) => s.messageReceived === true,
-  });
 
   client.close();
 }

--- a/k6/match_timeline_tournaments_feed.js
+++ b/k6/match_timeline_tournaments_feed.js
@@ -82,13 +82,15 @@ export default function () {
     console.log('TournamentsFeed stream error:', err.message);
   });
 
+  stream.on('end', () => {
+    check(state, {
+      '[MatchTimelineTournamentsFeed] Received at least one message': (s) => s.messageReceived === true,
+    });
+  });
+
   stream.write({ liveOnly: false, sport: 'SPORT_CS2' });
 
   sleep(10);
-
-  check(state, {
-    '[MatchTimelineTournamentsFeed] Received at least one message': (s) => s.messageReceived === true,
-  });
 
   client.close();
 }


### PR DESCRIPTION
## Summary

Fixes the 5 `k6/*_feed.js` streaming tests, which were failing on every run after the original PR #47 was merged. Two unrelated bugs:

- **State assertions fired before stream callbacks ran.** The post-`sleep()` `check(state, ...)` block never saw populated state — k6 dispatches gRPC stream `on('data')` callbacks during iteration teardown, not during `sleep()`. Moved the assertions into `stream.on('end')`, which fires after the stream is drained and state is fully observable. Applies to all 5 feed tests.
- **`google.protobuf.Timestamp` shape assumption was wrong.** Two checks expected `{seconds, nanos}` objects, but k6/gRPC marshals `Timestamp` as an ISO 8601 string (e.g. `"2026-04-30T11:00:00Z"`). Fixed in `match_timeline_feed.js` (`plannetStart`) and `match_events_feed.js` (event `timestamp`), and ordering checks now use `Date.parse`.

## Test plan

- [x] Full local suite against `api-bragi-test.integration.oddin.dev:443` with a valid `BRAGI_TOKEN`: **9/9 tests pass, 1122/1122 checks succeed**
- [ ] Verify on another developer's machine (e.g., re-run after pull)
- [ ] (Optional follow-up) Once CI is enabled, confirm the workflow run is green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)