### PR TITLE
Tolerate omitted isOffline on tournaments feed

### DIFF
--- a/k6/match_timeline_tournaments_feed.js
+++ b/k6/match_timeline_tournaments_feed.js
@@ -61,7 +61,7 @@ export default function () {
             '[TournamentsFeed] Tournament urn starts with od:tournament:': (t) =>
               t.urn.startsWith('od:tournament:'),
             '[TournamentsFeed] Tournament has isOffline boolean': (t) =>
-              typeof t.isOffline === 'boolean',
+              t.isOffline === undefined || typeof t.isOffline === 'boolean',
           });
         }
 

--- a/k6/match_timeline_tournaments_feed.js
+++ b/k6/match_timeline_tournaments_feed.js
@@ -60,7 +60,7 @@ export default function () {
               typeof t.name === 'string' && t.name.length > 0,
             '[TournamentsFeed] Tournament urn starts with od:tournament:': (t) =>
               t.urn.startsWith('od:tournament:'),
-            '[TournamentsFeed] Tournament has isOffline boolean': (t) =>
+            '[TournamentsFeed] Tournament has optional isOffline boolean': (t) =>
               t.isOffline === undefined || typeof t.isOffline === 'boolean',
           });
         }


### PR DESCRIPTION
## Summary

Relax the `[TournamentsFeed] Tournament has isOffline boolean` check in `match_timeline_tournaments_feed.js` to accept `undefined` alongside boolean.

## Why

The check asserts `typeof t.isOffline === 'boolean'`, which fails when the server JSON-marshaler omits `bool is_offline = false` (proto3 default-value omission). This was reproducible on Anna's machine after #51 landed, but not on mine — the server's emission behavior is environmental and not something the test should depend on.

Accepting `undefined` is semantically equivalent (an omitted `false` is still `false`), and removes the env-dependent flakiness.

## Test plan

- [x] `BRAGI_TOKEN=… k6 run k6/match_timeline_tournaments_feed.js` — 12/12 checks pass
- [ ] Anna to re-pull and confirm 9/9 tests now green on her machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)